### PR TITLE
perf: cache auth queries with 5-min TTL (#6)

### DIFF
--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -99,4 +99,8 @@ export const CACHE_KEYS = {
   USER_PREFIX: "user:",
   /** Per-user profile. Key: `profile:{userId}` */
   PROFILE_PREFIX: "profile:",
+  /** User lookup by email. Key: `user_email:{normalised_email}` */
+  USER_BY_EMAIL_PREFIX: "user_email:",
+  /** User lookup by external sub ID. Key: `user_sub:{subId}` */
+  USER_BY_SUB_PREFIX: "user_sub:",
 } as const;

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -28,12 +28,22 @@ export function getUserById(id: string): UserRecord | undefined {
   );
 }
 
+const AUTH_CACHE_TTL_MS = 300_000; // 5 minutes
+
 export function getUserByEmail(email: string): UserRecord | undefined {
-  return stmt("SELECT * FROM users WHERE email = ? COLLATE NOCASE").get(email) as UserRecord | undefined;
+  return appCache.get(
+    `${CACHE_KEYS.USER_BY_EMAIL_PREFIX}${email.toLowerCase()}`,
+    () => stmt("SELECT * FROM users WHERE email = ? COLLATE NOCASE").get(email) as UserRecord | undefined,
+    AUTH_CACHE_TTL_MS
+  );
 }
 
 export function getUserByExternalSub(subId: string): UserRecord | undefined {
-  return stmt("SELECT * FROM users WHERE external_sub_id = ?").get(subId) as UserRecord | undefined;
+  return appCache.get(
+    `${CACHE_KEYS.USER_BY_SUB_PREFIX}${subId}`,
+    () => stmt("SELECT * FROM users WHERE external_sub_id = ?").get(subId) as UserRecord | undefined,
+    AUTH_CACHE_TTL_MS
+  );
 }
 
 export function createUser(args: {
@@ -70,6 +80,7 @@ export function createUser(args: {
 
 export function updateUserPassword(userId: string, passwordHash: string): void {
   getDb().prepare("UPDATE users SET password_hash = ? WHERE id = ?").run(passwordHash, userId);
+  invalidateUserCaches(userId);
 }
 
 export function listUsers(): UserRecord[] {
@@ -148,12 +159,12 @@ export function getUserPermissions(userId: string): UserPermissions | undefined 
 export function updateUserRole(userId: string, role: string): void {
   if (!["admin", "user"].includes(role)) throw new Error("Invalid role");
   getDb().prepare("UPDATE users SET role = ? WHERE id = ?").run(role, userId);
-  appCache.invalidate(`${CACHE_KEYS.USER_PREFIX}${userId}`);
+  invalidateUserCaches(userId);
 }
 
 export function updateUserEnabled(userId: string, enabled: boolean): void {
   getDb().prepare("UPDATE users SET enabled = ? WHERE id = ?").run(enabled ? 1 : 0, userId);
-  appCache.invalidate(`${CACHE_KEYS.USER_PREFIX}${userId}`);
+  invalidateUserCaches(userId);
 }
 
 export function updateUserPermissions(userId: string, perms: Partial<Omit<UserPermissions, "user_id">>): void {
@@ -174,14 +185,32 @@ export function updateUserPermissions(userId: string, perms: Partial<Omit<UserPe
 }
 
 export function deleteUser(userId: string): void {
+  // Capture email/sub before deletion so we can invalidate their cache entries
+  const existing = getUserById(userId);
   getDb().prepare("DELETE FROM users WHERE id = ?").run(userId);
-  appCache.invalidate(`${CACHE_KEYS.USER_PREFIX}${userId}`);
+  invalidateUserCaches(userId, existing);
   appCache.invalidate(`${CACHE_KEYS.PROFILE_PREFIX}${userId}`);
 }
 
 export function isUserEnabled(userId: string): boolean {
-  const row = stmt("SELECT enabled FROM users WHERE id = ?").get(userId) as { enabled?: number } | undefined;
-  return (row?.enabled ?? 1) === 1;
+  const user = getUserById(userId);
+  return ((user as unknown as { enabled?: number })?.enabled ?? 1) === 1;
+}
+
+/**
+ * Invalidate all cache entries related to a user (by-id, by-email, by-sub).
+ * If `known` is provided, uses it to build the email/sub keys; otherwise
+ * reads the current record from the by-id cache before clearing it.
+ */
+function invalidateUserCaches(userId: string, known?: UserRecord): void {
+  const user = known ?? getUserById(userId);
+  appCache.invalidate(`${CACHE_KEYS.USER_PREFIX}${userId}`);
+  if (user?.email) {
+    appCache.invalidate(`${CACHE_KEYS.USER_BY_EMAIL_PREFIX}${user.email.toLowerCase()}`);
+  }
+  if (user?.external_sub_id) {
+    appCache.invalidate(`${CACHE_KEYS.USER_BY_SUB_PREFIX}${user.external_sub_id}`);
+  }
 }
 
 // â”€â”€â”€ Identity (legacy â€” kept for backward compat) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€

--- a/tests/unit/db/users.test.ts
+++ b/tests/unit/db/users.test.ts
@@ -5,17 +5,20 @@ import { setupTestDb, teardownTestDb, seedTestUser } from "../../helpers/test-db
 import {
   getUserById,
   getUserByEmail,
+  getUserByExternalSub,
   createUser,
   listUsers,
   getUserCount,
   updateUserRole,
   updateUserEnabled,
+  updateUserPassword,
   isUserEnabled,
   deleteUser,
   updateUserPermissions,
   getUserPermissions,
   listUsersWithPermissions,
 } from "@/lib/db/queries";
+import { appCache } from "@/lib/cache";
 
 beforeAll(() => setupTestDb());
 afterAll(() => teardownTestDb());
@@ -190,5 +193,99 @@ describe("User Permissions", () => {
       expect(u.permissions).toBeDefined();
       expect(typeof u.permissions.chat).toBe("number");
     }
+  });
+});
+
+describe("Auth query caching & invalidation", () => {
+  let userId: string;
+  const email = "cache-test@example.com";
+
+  beforeAll(() => {
+    const user = createUser({
+      email,
+      providerId: "local",
+      externalSubId: "ext-sub-cache-test",
+      role: "admin",
+    });
+    userId = user.id;
+  });
+
+  beforeEach(() => {
+    appCache.invalidateAll();
+  });
+
+  test("getUserByEmail returns cached result on second call", () => {
+    const first = getUserByEmail(email);
+    const second = getUserByEmail(email);
+    expect(first).toEqual(second);
+    // Both should be the same reference (cache hit)
+    expect(first).toBe(second);
+  });
+
+  test("getUserByExternalSub returns cached result on second call", () => {
+    const first = getUserByExternalSub("ext-sub-cache-test");
+    const second = getUserByExternalSub("ext-sub-cache-test");
+    expect(first).toEqual(second);
+    expect(first).toBe(second);
+  });
+
+  test("updateUserRole invalidates email and sub caches", () => {
+    const before = getUserByEmail(email);
+    expect(before!.role).toBe("admin");
+
+    updateUserRole(userId, "user");
+    const after = getUserByEmail(email);
+    expect(after!.role).toBe("user");
+    // Should not be the same reference — cache was invalidated
+    expect(after).not.toBe(before);
+
+    // Restore
+    updateUserRole(userId, "admin");
+  });
+
+  test("updateUserEnabled invalidates email cache", () => {
+    getUserByEmail(email); // warm cache
+    updateUserEnabled(userId, false);
+
+    const after = getUserByEmail(email);
+    expect(isUserEnabled(userId)).toBe(false);
+
+    updateUserEnabled(userId, true);
+  });
+
+  test("updateUserPassword invalidates user caches", () => {
+    const before = getUserByEmail(email);
+    updateUserPassword(userId, "new-hash-123");
+
+    const after = getUserByEmail(email);
+    expect(after!.password_hash).toBe("new-hash-123");
+    expect(after).not.toBe(before);
+  });
+
+  test("deleteUser invalidates all user cache entries", () => {
+    const tempUser = createUser({
+      email: "cache-del@example.com",
+      providerId: "local",
+      externalSubId: "ext-del-test",
+    });
+
+    // Warm all caches
+    getUserByEmail("cache-del@example.com");
+    getUserByExternalSub("ext-del-test");
+    getUserById(tempUser.id);
+
+    deleteUser(tempUser.id);
+
+    expect(getUserById(tempUser.id)).toBeUndefined();
+    expect(getUserByEmail("cache-del@example.com")).toBeUndefined();
+    expect(getUserByExternalSub("ext-del-test")).toBeUndefined();
+  });
+
+  test("getUserByEmail cache is case-insensitive", () => {
+    const lower = getUserByEmail(email);
+    appCache.invalidateAll();
+    const upper = getUserByEmail(email.toUpperCase());
+    // Both should resolve the same user (COLLATE NOCASE)
+    expect(lower!.id).toBe(upper!.id);
   });
 });


### PR DESCRIPTION
## PERF-05: Cache auth queries

Caches getUserByEmail() and getUserByExternalSub() with 5-minute TTL.

### Changes
- Added USER_BY_EMAIL_PREFIX and USER_BY_SUB_PREFIX to CACHE_KEYS
- Wrapped auth lookup functions with AppCache
- All user mutation functions now invalidate by-id, by-email, and by-sub caches
- isUserEnabled() uses cached getUserById() instead of direct DB query
- Added invalidateUserCaches() helper

### Tests
- 7 new cache invalidation tests
- Full suite: 88 suites, 1133 tests passing

Closes #6