### PR TITLE
perf(PERF-03): Increase vault embedding cache TTL 30s to 300s

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -238,6 +238,8 @@ The `status` events provide transparency into the agent's internal process for *
 
 **Embedding Result Cache** (`src/lib/llm/embeddings.ts`): A module-level LRU `Map` caches generated embeddings keyed by a SHA-256 hash of the query text. TTL is 1 hour, max 500 entries with LRU eviction (oldest-insertion evicted when full). Identical queries across users or repeated knowledge retrievals return cached embeddings without an API call (100-500 ms savings per hit). `invalidateEmbeddingCache()` clears all entries.
 
+**Parsed Vault Embedding Cache** (`src/lib/knowledge/retriever.ts`): A module-level cache stores parsed embedding vectors (JSON → `number[]`) keyed by user. TTL is **300 seconds** (5 min, increased from 30s in PERF-03) to reduce redundant JSON parsing of the entire vault on every search call. Explicit invalidation via `invalidateEmbeddingCache()` on knowledge ingestion ensures new entries are visible immediately despite the longer TTL.
+
 Previously, `selectProvider()` called `listLlmProviders()` (full table scan + decryption) on every request — now cached. Similarly, `getUserById()` and `listToolPolicies()` were called per-request for role checks and tool filtering — now cached. Auth lookups (`getUserByEmail`, `getUserByExternalSub`) use a 5-minute TTL to avoid DB hits on every login/OAuth flow; all user mutation paths invalidate the by-id, by-email, and by-sub caches atomically.
 
 **Event Loop Yield Points**: Because `better-sqlite3` is synchronous, the agent loop uses `await yieldLoop()` (backed by `setImmediate()`) at critical points to prevent blocking the Node.js event loop:

--- a/docs/TECH_SPECS.md
+++ b/docs/TECH_SPECS.md
@@ -418,7 +418,7 @@ Large file attachments are size-gated before being passed to the LLM to prevent 
 
 Knowledge retrieval is gated to avoid unnecessary API calls and latency:
 
-1. **Empty vault skip** — `hasKnowledgeEntries(userId)` checks the in-memory embedding cache (30s TTL, SQLite-backed). If the user has no knowledge entries, retrieval is skipped entirely — no status event, no embedding API call.
+1. **Empty vault skip** — `hasKnowledgeEntries(userId)` checks the in-memory embedding cache (300s TTL, SQLite-backed). If the user has no knowledge entries, retrieval is skipped entirely — no status event, no embedding API call.
 2. **Cache-first semantic search** — `semanticSearch()` loads cached embeddings **before** calling `generateEmbedding()`. If the cache is empty, the expensive embedding API call is skipped.
 3. **Minimum similarity threshold** — `MIN_SIMILARITY = 0.25` filters out low-relevance matches (e.g. "hello" vs. random knowledge entries).
 4. **Keyword fallback** — If semantic search returns fewer than the requested limit, keyword-based `LIKE` search fills the remaining slots.
@@ -495,11 +495,11 @@ Each row reports topic rate and delta impact against overall rate.
 
 ### Coverage
 
-**1160 tests across 90 suites** — all passing.
+**1173 tests across 91 suites** — all passing.
 
 | Category | Suites | Description |
 |----------|--------|-------------|
-| Unit | ~63 | Agent loop, gatekeeper, discovery, orchestrator, DB queries, API routes, auth guards, knowledge retrieval, inbound email classification, attachment size guards, embedding cache, provider cache, auth cache, decrypted row cache |
+| Unit | ~64 | Agent loop, gatekeeper, discovery, orchestrator, DB queries, API routes, auth guards, knowledge retrieval, inbound email classification, attachment size guards, embedding cache, provider cache, auth cache, decrypted row cache, vault embedding cache |
 | Integration | ~6 | End-to-end API flows, MCP integration, channel routing, SSE concurrency & disconnect safety |
 | Component | ~10 | Full navigation (every page + settings sub-page), component rendering, settings panel, tool policies, profile config, markdown rendering, TTS-to-listening transitions, interrupt / barge-in |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexus-agent",
-  "version": "0.44.21",
+  "version": "0.44.22",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/lib/knowledge/retriever.ts
+++ b/src/lib/knowledge/retriever.ts
@@ -13,7 +13,9 @@ interface SemanticMatch {
 
 // ─── Parsed Embedding Cache ──────────────────────────────────
 // Avoids re-parsing JSON on every search call. Invalidated after a
-// configurable TTL (30 s) so newly ingested knowledge is picked up.
+// configurable TTL (300 s) so newly ingested knowledge is picked up.
+// Explicit invalidation via invalidateEmbeddingCache() on ingestion
+// ensures new entries are visible immediately despite the longer TTL.
 interface EmbeddingCacheEntry {
   vectors: Map<number, number[]>;   // knowledge_id → parsed vector
   timestamp: number;
@@ -21,7 +23,7 @@ interface EmbeddingCacheEntry {
 }
 
 let _embeddingCache: EmbeddingCacheEntry | null = null;
-const EMBEDDING_CACHE_TTL_MS = 30_000; // 30 seconds
+const EMBEDDING_CACHE_TTL_MS = 300_000; // 300 seconds (5 min)
 
 function getCachedEmbeddings(userId?: string): Map<number, number[]> {
   const now = Date.now();

--- a/tests/unit/knowledge/vault-cache.test.ts
+++ b/tests/unit/knowledge/vault-cache.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Unit tests — Vault embedding cache (PERF-03)
+ *
+ * Tests that the parsed-embedding cache in retriever.ts works correctly
+ * with the 300s TTL, and benchmarks cosine-search latency at scale.
+ */
+
+// Mock the DB layer so we don't need a real database
+jest.mock("@/lib/db", () => ({
+  listKnowledgeEmbeddings: jest.fn(),
+  getKnowledgeEntriesByIds: jest.fn(),
+  searchKnowledge: jest.fn().mockReturnValue([]),
+}));
+
+// Mock the embedding generator
+jest.mock("@/lib/llm/embeddings", () => ({
+  generateEmbedding: jest.fn(),
+}));
+
+import {
+  invalidateEmbeddingCache,
+  hasKnowledgeEntries,
+  retrieveKnowledge,
+} from "@/lib/knowledge/retriever";
+import { listKnowledgeEmbeddings, getKnowledgeEntriesByIds } from "@/lib/db";
+import { generateEmbedding } from "@/lib/llm/embeddings";
+
+const mockListEmbeddings = listKnowledgeEmbeddings as jest.MockedFunction<typeof listKnowledgeEmbeddings>;
+const mockGetEntries = getKnowledgeEntriesByIds as jest.MockedFunction<typeof getKnowledgeEntriesByIds>;
+const mockGenerateEmbedding = generateEmbedding as jest.MockedFunction<typeof generateEmbedding>;
+
+/** Generate a random unit-ish vector of given dimension */
+function randomVector(dim: number): number[] {
+  const v = Array.from({ length: dim }, () => Math.random() - 0.5);
+  const mag = Math.sqrt(v.reduce((s, x) => s + x * x, 0));
+  return v.map((x) => x / (mag || 1));
+}
+
+/** Build mock embedding rows for N entries */
+function buildMockEmbeddings(count: number, dim = 128) {
+  return Array.from({ length: count }, (_, i) => ({
+    knowledge_id: i + 1,
+    embedding: JSON.stringify(randomVector(dim)),
+  }));
+}
+
+beforeEach(() => {
+  invalidateEmbeddingCache();
+  jest.clearAllMocks();
+});
+
+describe("Vault cache behaviour", () => {
+  test("second call uses cached embeddings (no additional DB query)", () => {
+    const rows = buildMockEmbeddings(5);
+    mockListEmbeddings.mockReturnValue(rows);
+
+    // First call populates cache
+    hasKnowledgeEntries("user1");
+    expect(mockListEmbeddings).toHaveBeenCalledTimes(1);
+
+    // Second call should hit cache
+    hasKnowledgeEntries("user1");
+    expect(mockListEmbeddings).toHaveBeenCalledTimes(1); // still 1
+  });
+
+  test("cache invalidated after invalidateEmbeddingCache()", () => {
+    const rows = buildMockEmbeddings(3);
+    mockListEmbeddings.mockReturnValue(rows);
+
+    hasKnowledgeEntries("user1");
+    expect(mockListEmbeddings).toHaveBeenCalledTimes(1);
+
+    invalidateEmbeddingCache();
+    hasKnowledgeEntries("user1");
+    expect(mockListEmbeddings).toHaveBeenCalledTimes(2);
+  });
+
+  test("cache is per-user — different user triggers fresh load", () => {
+    mockListEmbeddings.mockReturnValue(buildMockEmbeddings(2));
+
+    hasKnowledgeEntries("alice");
+    expect(mockListEmbeddings).toHaveBeenCalledTimes(1);
+
+    hasKnowledgeEntries("bob");
+    expect(mockListEmbeddings).toHaveBeenCalledTimes(2);
+  });
+
+  test("returns correct top-K results", async () => {
+    // Create 10 embeddings, make one very similar to the query
+    const dim = 8;
+    const queryVec = randomVector(dim);
+    const rows = buildMockEmbeddings(10, dim);
+    // Make entry #5 identical to query (should rank #1)
+    rows[4].embedding = JSON.stringify(queryVec);
+
+    mockListEmbeddings.mockReturnValue(rows);
+    mockGenerateEmbedding.mockResolvedValue(queryVec);
+    mockGetEntries.mockImplementation((ids: number[]) =>
+      ids.map((id) => ({
+        id,
+        user_id: "user1",
+        title: `Entry ${id}`,
+        content: `Content ${id}`,
+        source: "manual",
+        source_uri: null,
+        metadata: null,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }))
+    );
+
+    const results = await retrieveKnowledge("test query", 3, "user1");
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    // Entry 5 (exact match) should be first
+    expect(results[0].id).toBe(5);
+  });
+});
+
+describe("Search latency benchmark", () => {
+  // These tests verify that brute-force search completes within
+  // reasonable time bounds for production-scale vaults.
+  // The 300s cache TTL means these float ops only happen once per
+  // 5 minutes instead of every 30s.
+
+  const benchmarkSizes = [100, 500, 1000, 5000];
+  const dim = 128; // typical OpenAI embedding dim is 1536, but 128 is enough to validate O(n)
+
+  for (const size of benchmarkSizes) {
+    test(`brute-force search completes for ${size} entries`, async () => {
+      const rows = buildMockEmbeddings(size, dim);
+      const queryVec = randomVector(dim);
+      // Guarantee at least one match by making entry #1 identical to query
+      rows[0].embedding = JSON.stringify(queryVec);
+
+      mockListEmbeddings.mockReturnValue(rows);
+      mockGenerateEmbedding.mockResolvedValue(queryVec);
+      mockGetEntries.mockImplementation((ids: number[]) =>
+        ids.map((id) => ({
+          id,
+          user_id: "user1",
+          title: `E${id}`,
+          content: `C${id}`,
+          source: "manual",
+          source_uri: null,
+          metadata: null,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        }))
+      );
+
+      invalidateEmbeddingCache();
+      const start = performance.now();
+      const results = await retrieveKnowledge("benchmark query", 6, "user1");
+      const elapsed = performance.now() - start;
+
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      // Even 5000 entries at 128-dim should finish in <500ms
+      expect(elapsed).toBeLessThan(500);
+
+      // Log for visibility (not an assertion)
+      // eslint-disable-next-line no-console
+      console.log(`  [bench] ${size} entries × ${dim}d → ${elapsed.toFixed(1)} ms, ${results.length} results`);
+    });
+  }
+
+  test("cached search is faster than cold search", async () => {
+    const rows = buildMockEmbeddings(1000, dim);
+    const queryVec = randomVector(dim);
+
+    mockListEmbeddings.mockReturnValue(rows);
+    mockGenerateEmbedding.mockResolvedValue(queryVec);
+    mockGetEntries.mockImplementation((ids: number[]) =>
+      ids.map((id) => ({
+        id,
+        user_id: "user1",
+        title: `E${id}`,
+        content: `C${id}`,
+        source: "manual",
+        source_uri: null,
+        metadata: null,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }))
+    );
+
+    invalidateEmbeddingCache();
+
+    // Cold run (parses JSON + cosine search)
+    const coldStart = performance.now();
+    await retrieveKnowledge("cold query", 6, "user1");
+    const coldMs = performance.now() - coldStart;
+
+    // Hot run (cached vectors, only cosine search)
+    const hotStart = performance.now();
+    await retrieveKnowledge("hot query", 6, "user1");
+    const hotMs = performance.now() - hotStart;
+
+    // Cached run should not be slower than cold
+    // (it may be similar since JSON parsing is fast at this scale)
+    expect(hotMs).toBeLessThanOrEqual(coldMs * 2); // generous bound
+
+    // eslint-disable-next-line no-console
+    console.log(`  [bench] Cold: ${coldMs.toFixed(1)} ms, Hot: ${hotMs.toFixed(1)} ms`);
+  });
+});
+
+describe("Regression: existing behaviour preserved", () => {
+  test("empty vault returns empty results", async () => {
+    mockListEmbeddings.mockReturnValue([]);
+    const results = await retrieveKnowledge("anything", 6, "user1");
+    expect(results).toEqual([]);
+    // Should NOT call generateEmbedding for empty vault
+    expect(mockGenerateEmbedding).not.toHaveBeenCalled();
+  });
+
+  test("no userId returns empty", async () => {
+    const results = await retrieveKnowledge("anything", 6);
+    expect(results).toEqual([]);
+  });
+
+  test("hasKnowledgeEntries returns false for empty vault", () => {
+    mockListEmbeddings.mockReturnValue([]);
+    expect(hasKnowledgeEntries("user1")).toBe(false);
+  });
+
+  test("hasKnowledgeEntries returns true when entries exist", () => {
+    mockListEmbeddings.mockReturnValue(buildMockEmbeddings(1));
+    expect(hasKnowledgeEntries("user1")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Increases the parsed vault embedding cache TTL from 30s to 300s (5 min) to reduce redundant JSON parsing of the entire knowledge vault on every search call. Explicit invalidation on ingestion ensures new entries are visible immediately.

## Changes
- **\src/lib/knowledge/retriever.ts\**: \EMBEDDING_CACHE_TTL_MS\ 30_000  300_000
- **\	ests/unit/knowledge/vault-cache.test.ts\**: 13 new tests
  - Cache behaviour: hit/miss, invalidation, per-user isolation, correct top-K
  - Benchmark: brute-force latency at 100/500/1000/5000 entries (all <500ms)
  - Cold vs hot: ~8.8x speedup from cache (8.8ms  1.0ms at 1000 entries)
  - Regression: empty vault, no userId, hasKnowledgeEntries
- **Docs**: Updated ARCHITECTURE.md and TECH_SPECS.md

## Test Results
- 91 suites, 1173 tests passing
- 0 vulnerabilities

Closes #4