### PR TITLE
perf(PERF-07): fix N+1 notifications/approvals query

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -250,6 +250,11 @@ Previously, `selectProvider()` called `listLlmProviders()` (full table scan + de
 
 This ensures other HTTP requests (including new tabs, API calls, and the conversation endpoint) can be served even while a long-running agent loop with multiple tool calls is executing.
 
+**Approval Query Optimization** (`src/lib/db/queries.ts`): The `/api/notifications` and `/api/approvals` GET handlers previously suffered from an N+1 query pattern — each pending approval triggered a separate `getThread()` call to verify ownership and staleness. This was replaced with:
+
+- `listPendingApprovalsForUser(userId)` — a single `JOIN` query (`approval_queue ⨝ threads`) that returns only the current user's pending approvals in O(1) queries instead of O(n).
+- `cleanStaleApprovals()` — a bulk `UPDATE` that rejects orphaned approvals (deleted thread) and stale approvals (thread no longer in `awaiting_approval` status) in two statements, replacing per-row staleness checks. Proactive approvals (`thread_id IS NULL`) are preserved.
+
 ### Notification & Inbound Email Safety Path
 
 - **Per-user thresholds** — Channel notifications are filtered by each user profile's `notification_level` (`low`, `medium`, `high`, `disaster`).

--- a/docs/TECH_SPECS.md
+++ b/docs/TECH_SPECS.md
@@ -271,7 +271,7 @@ The `app_config` table stores application-wide settings as key-value pairs. Sens
 | `GET/POST` | `/api/mcp` | User | List/add MCP servers (global + user-scoped) |
 | `POST` | `/api/mcp/[serverId]/connect` | Auth | Connect to an MCP server |
 | `GET` | `/api/mcp/tools` | Auth | List all available MCP tools |
-| `GET/POST` | `/api/approvals` | Auth | List/resolve pending approvals (includes proactive/threadless approvals for admins) |
+| `GET/POST` | `/api/approvals` | Auth | List/resolve pending approvals (O(1) JOIN query; stale approvals auto-cleaned) |
 | `GET/POST` | `/api/policies` | Auth | List/update tool policies |
 | `GET` | `/api/logs` | Auth | Fetch agent activity logs |
 | `GET/POST` | `/api/config/llm` | Auth | Manage LLM provider configs |
@@ -495,7 +495,7 @@ Each row reports topic rate and delta impact against overall rate.
 
 ### Coverage
 
-**1173 tests across 91 suites** — all passing.
+**1182 tests across 92 suites** — all passing.
 
 | Category | Suites | Description |
 |----------|--------|-------------|

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexus-agent",
-  "version": "0.44.10",
+  "version": "0.44.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexus-agent",
-      "version": "0.44.10",
+      "version": "0.44.23",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
         "@azure/openai": "^2.0.0",
@@ -9257,12 +9257,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
+      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -10476,9 +10476,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexus-agent",
-  "version": "0.44.22",
+  "version": "0.44.23",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/api/approvals/route.ts
+++ b/src/app/api/approvals/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireUser } from "@/lib/auth/guard";
-import { listPendingApprovals, getApprovalById, updateApprovalStatus, updateThreadStatus, getThreadMessages, addMessage, getThread, addLog } from "@/lib/db";
+import { listPendingApprovals, listPendingApprovalsForUser, cleanStaleApprovals, getApprovalById, updateApprovalStatus, updateThreadStatus, getThreadMessages, addMessage, getThread, addLog } from "@/lib/db";
 import { executeApprovedTool, continueAgentLoop } from "@/lib/agent";
 import { executeProactiveApprovedTool } from "@/lib/scheduler";
 import type { ToolCall } from "@/lib/llm";
@@ -11,41 +11,17 @@ export async function GET() {
 
   const all = listPendingApprovals();
 
-  // Clean up stale approvals: auto-reject entries whose thread no longer exists
-  // or whose thread is no longer awaiting_approval (i.e. the action is no longer
-  // blocking anything — these are not actionable).
-  // Proactive approvals (thread_id === null) are always actionable since they
-  // originate from the scheduler and have no associated chat thread.
-  const actionable: typeof all = [];
-  for (const a of all) {
-    if (!a.thread_id) {
-      // Proactive scheduler approval — no thread needed, always actionable
-      actionable.push(a);
-      continue;
-    }
-    const thread = getThread(a.thread_id);
-    if (!thread) {
-      // Thread was deleted — reject the orphaned approval
-      updateApprovalStatus(a.id, "rejected");
-      continue;
-    }
-    if (thread.status !== "awaiting_approval") {
-      // Thread is active/completed — this approval is stale, auto-reject
-      updateApprovalStatus(a.id, "rejected");
-      continue;
-    }
-    actionable.push(a);
-  }
+  // Clean up stale approvals in bulk (O(1) queries, not O(n) per-approval loop)
+  cleanStaleApprovals();
+
+  // Re-fetch after cleanup to get only actionable approvals
+  const actionable = listPendingApprovals();
 
   // Scope visibility: admins see all, regular users see only their threads
   // Proactive approvals (no thread) are admin-only
   const pending = auth.user.role === "admin"
     ? actionable
-    : actionable.filter((a) => {
-        if (!a.thread_id) return false; // Proactive approvals are admin-only
-        const thread = getThread(a.thread_id);
-        return thread?.user_id === auth.user.id;
-      });
+    : listPendingApprovalsForUser(auth.user.id);
 
   return NextResponse.json(pending);
 }

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -7,8 +7,8 @@ import {
   markAllNotificationsRead,
   deleteNotification,
   listPendingApprovals,
-  getThread,
-  updateApprovalStatus,
+  listPendingApprovalsForUser,
+  cleanStaleApprovals,
 } from "@/lib/db";
 
 /**
@@ -26,24 +26,13 @@ export async function GET() {
   const notifications = listNotifications(userId);
   const unreadCount = countUnreadNotifications(userId);
 
-  // Fetch pending approvals and include them as notification items
-  const allApprovals = listPendingApprovals();
-  const approvals = isAdmin
-    ? allApprovals
-    : allApprovals.filter((a) => {
-        if (!a.thread_id) return false;
-        const thread = getThread(a.thread_id);
-        return thread?.user_id === userId;
-      });
+  // Clean stale approvals in bulk (O(1) queries, not O(n))
+  cleanStaleApprovals();
 
-  // Auto-clean stale approvals
-  for (const a of allApprovals) {
-    if (!a.thread_id) continue;
-    const thread = getThread(a.thread_id);
-    if (!thread || thread.status !== "awaiting_approval") {
-      updateApprovalStatus(a.id, "rejected");
-    }
-  }
+  // Fetch pending approvals — single JOIN query for non-admins
+  const approvals = isAdmin
+    ? listPendingApprovals()
+    : listPendingApprovalsForUser(userId);
 
   return NextResponse.json({
     notifications,

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -939,6 +939,50 @@ export function listPendingApprovals(): ApprovalRequest[] {
   ).all() as ApprovalRequest[];
 }
 
+/**
+ * Return pending approvals scoped to threads owned by `userId`.
+ * Uses a single JOIN — O(1) queries instead of O(n).
+ * Proactive approvals (thread_id IS NULL) are excluded for non-admin callers.
+ */
+export function listPendingApprovalsForUser(userId: string): ApprovalRequest[] {
+  return getDb()
+    .prepare(
+      `SELECT a.* FROM approval_queue a
+       JOIN threads t ON a.thread_id = t.id
+       WHERE a.status = 'pending' AND t.user_id = ?
+       ORDER BY a.created_at DESC`
+    )
+    .all(userId) as ApprovalRequest[];
+}
+
+/**
+ * Auto-reject stale pending approvals in bulk:
+ * - thread has been deleted (orphaned)
+ * - thread status is no longer 'awaiting_approval'
+ * Proactive approvals (thread_id IS NULL) are never touched.
+ * Returns the count of rejected rows.
+ */
+export function cleanStaleApprovals(): number {
+  const db = getDb();
+  // Reject approvals whose thread no longer exists
+  const orphaned = db
+    .prepare(
+      `UPDATE approval_queue SET status = 'rejected'
+       WHERE status = 'pending' AND thread_id IS NOT NULL
+         AND thread_id NOT IN (SELECT id FROM threads)`
+    )
+    .run();
+  // Reject approvals whose thread is no longer awaiting_approval
+  const stale = db
+    .prepare(
+      `UPDATE approval_queue SET status = 'rejected'
+       WHERE status = 'pending' AND thread_id IS NOT NULL
+         AND thread_id IN (SELECT id FROM threads WHERE status != 'awaiting_approval')`
+    )
+    .run();
+  return orphaned.changes + stale.changes;
+}
+
 export function updateApprovalStatus(id: string, status: "approved" | "rejected"): void {
   getDb().prepare("UPDATE approval_queue SET status = ? WHERE id = ?").run(status, id);
 }

--- a/tests/integration/api/notifications.test.ts
+++ b/tests/integration/api/notifications.test.ts
@@ -14,6 +14,7 @@ import {
   createNotification,
   createApprovalRequest,
   createThread,
+  updateThreadStatus,
 } from "@/lib/db/queries";
 
 let adminId: string;
@@ -57,6 +58,7 @@ describe("GET /api/notifications", () => {
   test("includes pending approvals for admin users", async () => {
     setMockUser({ id: adminId, email: "admin-notif@test.com", role: "admin" });
     const thread = createThread("test thread", adminId);
+    updateThreadStatus(thread.id, "awaiting_approval");
     createApprovalRequest({
       thread_id: thread.id,
       tool_name: "test_tool",

--- a/tests/unit/db/notifications-n1.test.ts
+++ b/tests/unit/db/notifications-n1.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Unit tests — N+1 fix: listPendingApprovalsForUser + cleanStaleApprovals (PERF-07)
+ */
+import { setupTestDb, teardownTestDb, seedTestUser } from "../../helpers/test-db";
+import {
+  createApprovalRequest,
+  listPendingApprovals,
+  listPendingApprovalsForUser,
+  cleanStaleApprovals,
+  updateApprovalStatus,
+  createThread,
+  updateThreadStatus,
+} from "@/lib/db/queries";
+import { getDb } from "@/lib/db";
+
+let userA: string;
+let userB: string;
+
+beforeAll(() => {
+  setupTestDb();
+  userA = seedTestUser({ email: "approvals-a@test.com" });
+  userB = seedTestUser({ email: "approvals-b@test.com" });
+});
+afterAll(() => teardownTestDb());
+
+describe("listPendingApprovalsForUser", () => {
+  test("returns only approvals for threads owned by the given user", () => {
+    const threadA = createThread("Thread A", userA);
+    const threadB = createThread("Thread B", userB);
+    updateThreadStatus(threadA.id, "awaiting_approval");
+    updateThreadStatus(threadB.id, "awaiting_approval");
+
+    createApprovalRequest({ thread_id: threadA.id, tool_name: "toolA", args: "{}", reasoning: null });
+    createApprovalRequest({ thread_id: threadB.id, tool_name: "toolB", args: "{}", reasoning: null });
+
+    const forA = listPendingApprovalsForUser(userA);
+    const forB = listPendingApprovalsForUser(userB);
+
+    expect(forA.every((a) => a.thread_id === threadA.id)).toBe(true);
+    expect(forB.every((a) => a.thread_id === threadB.id)).toBe(true);
+    expect(forA.length).toBeGreaterThanOrEqual(1);
+    expect(forB.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("excludes proactive approvals (thread_id IS NULL)", () => {
+    createApprovalRequest({ thread_id: null, tool_name: "proactive", args: "{}", reasoning: null });
+    const forA = listPendingApprovalsForUser(userA);
+    expect(forA.find((a) => a.tool_name === "proactive")).toBeUndefined();
+  });
+
+  test("returns empty for user with no threads", () => {
+    const noone = seedTestUser({ email: "nothreads@test.com" });
+    const result = listPendingApprovalsForUser(noone);
+    expect(result).toEqual([]);
+  });
+
+  test("ownership check done in single query (O(1) not O(n))", () => {
+    // Create 10 approvals across threads for userA and userB
+    const tA = createThread("Batch A", userA);
+    const tB = createThread("Batch B", userB);
+    updateThreadStatus(tA.id, "awaiting_approval");
+    updateThreadStatus(tB.id, "awaiting_approval");
+    for (let i = 0; i < 10; i++) {
+      createApprovalRequest({
+        thread_id: i < 5 ? tA.id : tB.id,
+        tool_name: `batch_tool_${i}`,
+        args: "{}",
+        reasoning: null,
+      });
+    }
+
+    // The function returns correct results — the O(1) vs O(n)
+    // guarantee is structural (single SQL JOIN), verified by existence of the test
+    const forA = listPendingApprovalsForUser(userA);
+    expect(forA.length).toBeGreaterThanOrEqual(5);
+    // All returned approvals must belong to userA's threads
+    const forAThreadIds = forA.map((a) => a.thread_id);
+    expect(forAThreadIds).toContain(tA.id);
+    expect(forAThreadIds).not.toContain(tB.id);
+  });
+});
+
+describe("cleanStaleApprovals", () => {
+  test("rejects approvals for deleted threads", () => {
+    const thread = createThread("Deletable", userA);
+    updateThreadStatus(thread.id, "awaiting_approval");
+    const req = createApprovalRequest({
+      thread_id: thread.id,
+      tool_name: "will_orphan",
+      args: "{}",
+      reasoning: null,
+    });
+
+    // Delete the thread (temporarily disable FK to simulate orphaned state)
+    const db = getDb();
+    db.pragma("foreign_keys = OFF");
+    db.prepare("DELETE FROM messages WHERE thread_id = ?").run(thread.id);
+    db.prepare("DELETE FROM threads WHERE id = ?").run(thread.id);
+    db.pragma("foreign_keys = ON");
+
+    // The approval now references a non-existent thread
+
+    const rejected = cleanStaleApprovals();
+    expect(rejected).toBeGreaterThanOrEqual(1);
+
+    // Approval should no longer appear in pending list
+    const pending = listPendingApprovals();
+    expect(pending.find((a) => a.id === req.id)).toBeUndefined();
+  });
+
+  test("rejects approvals for threads no longer awaiting_approval", () => {
+    const thread = createThread("Stale", userA);
+    updateThreadStatus(thread.id, "awaiting_approval");
+    const req = createApprovalRequest({
+      thread_id: thread.id,
+      tool_name: "stale_tool",
+      args: "{}",
+      reasoning: null,
+    });
+
+    // Move thread out of awaiting_approval
+    updateThreadStatus(thread.id, "active");
+
+    const rejected = cleanStaleApprovals();
+    expect(rejected).toBeGreaterThanOrEqual(1);
+
+    const pending = listPendingApprovals();
+    expect(pending.find((a) => a.id === req.id)).toBeUndefined();
+  });
+
+  test("does not touch proactive approvals (thread_id IS NULL)", () => {
+    const req = createApprovalRequest({
+      thread_id: null,
+      tool_name: "proactive_safe",
+      args: "{}",
+      reasoning: null,
+    });
+
+    cleanStaleApprovals();
+
+    const pending = listPendingApprovals();
+    expect(pending.find((a) => a.id === req.id)).toBeDefined();
+
+    // Clean up
+    updateApprovalStatus(req.id, "rejected");
+  });
+
+  test("does not touch valid awaiting_approval threads", () => {
+    const thread = createThread("Valid", userA);
+    updateThreadStatus(thread.id, "awaiting_approval");
+    const req = createApprovalRequest({
+      thread_id: thread.id,
+      tool_name: "valid_tool",
+      args: "{}",
+      reasoning: null,
+    });
+
+    cleanStaleApprovals();
+
+    const pending = listPendingApprovals();
+    expect(pending.find((a) => a.id === req.id)).toBeDefined();
+  });
+
+  test("performance: handles 50 approvals in bulk (not per-row)", () => {
+    const thread = createThread("BulkStale", userA);
+    updateThreadStatus(thread.id, "awaiting_approval");
+    for (let i = 0; i < 50; i++) {
+      createApprovalRequest({
+        thread_id: thread.id,
+        tool_name: `bulk_${i}`,
+        args: "{}",
+        reasoning: null,
+      });
+    }
+    // Make thread stale
+    updateThreadStatus(thread.id, "active");
+
+    const start = performance.now();
+    const rejected = cleanStaleApprovals();
+    const elapsed = performance.now() - start;
+
+    expect(rejected).toBeGreaterThanOrEqual(50);
+    // Bulk operation should be fast (< 100ms for 50 rows)
+    expect(elapsed).toBeLessThan(100);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #8  Replace N+1 per-approval getThread() calls with efficient single-query alternatives.

## Changes
- **listPendingApprovalsForUser(userId)**: Single JOIN query (approval_queue  threads) returns only the current user's pending approvals in O(1) queries instead of O(n)
- **cleanStaleApprovals()**: Bulk UPDATE that rejects orphaned approvals (deleted thread) and stale approvals (thread not in awaiting_approval status) in two statements
- Updated /api/notifications and /api/approvals GET handlers to use new functions
- Fixed express-rate-limit CVE via npm audit fix

## Testing
- 9 new unit tests (notifications-n1.test.ts)
- 1 integration test updated for new behavior
- **1182 tests across 92 suites  all passing**
- npm audit: 0 vulnerabilities