### PR TITLE
perf(PERF-18): debounce thread fetch calls (#19)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -438,7 +438,7 @@ src/
 │   ├── approval-inbox.tsx      # HITL approval UI (legacy, superseded by notification-bell)
 │   ├── auth-config.tsx         # Authentication provider configuration
 │   ├── channels-config.tsx     # Channel management (user-scoped)
-│   ├── chat-panel.tsx          # Thread/chat with inline approvals, real-time token streaming
+│   ├── chat-panel.tsx          # Thread/chat with inline approvals, real-time token streaming, debounced thread fetch
 │   ├── conversation-mode.tsx   # Full-screen voice conversation (VAD + TTS + worker thread)
 │   ├── custom-tools-config.tsx # Custom tools CRUD
 │   ├── knowledge-vault.tsx     # Knowledge CRUD

--- a/docs/TECH_SPECS.md
+++ b/docs/TECH_SPECS.md
@@ -496,7 +496,7 @@ Each row reports topic rate and delta impact against overall rate.
 
 ### Coverage
 
-**1206 tests across 94 suites** — all passing.
+**1216 tests across 95 suites** — all passing.
 
 | Category | Suites | Description |
 |----------|--------|-------------|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexus-agent",
-  "version": "0.44.25",
+  "version": "0.44.26",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/chat-panel.tsx
+++ b/src/components/chat-panel.tsx
@@ -146,6 +146,24 @@ export function ChatPanel() {
   const [resolvedApprovals, setResolvedApprovals] = useState<Record<string, string>>({});
   const [showSidebar, setShowSidebar] = useState(true);
 
+  // Debounced thread fetch — deduplicates concurrent calls and collapses rapid invocations
+  const threadFetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const threadFetchInFlightRef = useRef<Promise<void> | null>(null);
+  const fetchThreadsDebounced = useCallback((immediate = false) => {
+    if (threadFetchTimerRef.current) clearTimeout(threadFetchTimerRef.current);
+    const doFetch = () => {
+      if (threadFetchInFlightRef.current) return; // already in-flight — skip
+      const p = fetch("/api/threads")
+        .then((r) => r.json())
+        .then((d) => { if (Array.isArray(d)) setThreads(d); })
+        .catch(console.error)
+        .finally(() => { threadFetchInFlightRef.current = null; });
+      threadFetchInFlightRef.current = p;
+    };
+    if (immediate) { doFetch(); return; }
+    threadFetchTimerRef.current = setTimeout(doFetch, 400);
+  }, []);
+
   // Screen sharing state
   const [screenStream, setScreenStream] = useState<MediaStream | null>(null);
   const [screenSharing, setScreenSharing] = useState(false);
@@ -558,13 +576,11 @@ export function ChatPanel() {
     return () => document.removeEventListener("visibilitychange", onVisChange);
   }, []);
 
-  // Fetch threads
+  // Fetch threads on mount
   useEffect(() => {
-    fetch("/api/threads")
-      .then((r) => r.json())
-      .then((d) => { if (Array.isArray(d)) setThreads(d); })
-      .catch(console.error);
-  }, []);
+    fetchThreadsDebounced(true);
+    return () => { if (threadFetchTimerRef.current) clearTimeout(threadFetchTimerRef.current); };
+  }, [fetchThreadsDebounced]);
 
   // Fetch messages when thread changes — abort any in-flight SSE from the previous thread
   useEffect(() => {
@@ -594,10 +610,7 @@ export function ChatPanel() {
           .catch(console.error);
       }
       // Refresh thread list (status may have changed)
-      fetch("/api/threads")
-        .then((r) => r.json())
-        .then((d) => { if (Array.isArray(d)) setThreads(d); })
-        .catch(console.error);
+      fetchThreadsDebounced();
     }
     window.addEventListener("approval-resolved", handleApprovalResolved);
     return () => window.removeEventListener("approval-resolved", handleApprovalResolved);
@@ -699,7 +712,7 @@ export function ChatPanel() {
         const threadData = await threadRes.json();
         setMessages(threadData.messages || []);
       }
-      fetch("/api/threads").then((r) => r.json()).then((d) => { if (Array.isArray(d)) setThreads(d); }).catch(console.error);
+      fetchThreadsDebounced();
 
       // Notify other components (approval inbox, dashboard)
       window.dispatchEvent(new CustomEvent("approval-resolved", { detail: data }));
@@ -889,7 +902,7 @@ export function ChatPanel() {
                 });
               } else if (currentEvent === "done") {
                 // Agent loop completed — refresh thread list for auto-generated title
-                fetch("/api/threads").then((r) => r.json()).then((d) => { if (Array.isArray(d)) setThreads(d); }).catch(console.error);
+                fetchThreadsDebounced();
 
                 // Audio mode: speak the full streamed response
                 if (audioModeRef.current && audioModeTtsQueue.current.trim()) {

--- a/tests/unit/api/thread-fetch-debounce.test.ts
+++ b/tests/unit/api/thread-fetch-debounce.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit tests — Debounced thread fetch (PERF-18)
+ *
+ * Since ChatPanel can't be rendered in jest/jsdom (react-markdown is ESM-only),
+ * we verify:
+ *  1. Source code uses fetchThreadsDebounced instead of bare fetch("/api/threads")
+ *  2. The debounce + dedup logic works correctly in isolation
+ */
+
+import fs from "fs";
+import path from "path";
+
+const chatPanelSrc = fs.readFileSync(
+  path.join(__dirname, "../../../src/components/chat-panel.tsx"),
+  "utf-8"
+);
+
+describe("Source code verification", () => {
+  test("all thread list fetches go through fetchThreadsDebounced", () => {
+    // The only bare fetch("/api/threads") should be inside fetchThreadsDebounced itself
+    const bareMatches = [...chatPanelSrc.matchAll(/fetch\("\/api\/threads"\)/g)];
+    expect(bareMatches.length).toBe(1); // one inside the debounced function
+
+    // Should have multiple calls to fetchThreadsDebounced
+    const debouncedCalls = [...chatPanelSrc.matchAll(/fetchThreadsDebounced\(/g)];
+    expect(debouncedCalls.length).toBeGreaterThanOrEqual(4); // mount + approval-resolved + approval action + SSE done
+  });
+
+  test("debounce function deduplicates in-flight fetches", () => {
+    expect(chatPanelSrc).toContain("threadFetchInFlightRef");
+    expect(chatPanelSrc).toContain("if (threadFetchInFlightRef.current) return");
+  });
+
+  test("debounce timer is cleaned up on unmount", () => {
+    expect(chatPanelSrc).toContain("clearTimeout(threadFetchTimerRef.current)");
+  });
+
+  test("mount fetch uses immediate mode", () => {
+    expect(chatPanelSrc).toContain("fetchThreadsDebounced(true)");
+  });
+});
+
+describe("Debounce + dedup logic (isolated)", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  function createDebouncedFetch() {
+    const results: number[] = [];
+    let callCount = 0;
+    let inFlight: Promise<void> | null = null;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    function fetchThreadsDebounced(immediate = false) {
+      if (timer) clearTimeout(timer);
+      const doFetch = () => {
+        if (inFlight) return;
+        const id = ++callCount;
+        const p = Promise.resolve()
+          .then(() => results.push(id))
+          .finally(() => { inFlight = null; });
+        inFlight = p;
+      };
+      if (immediate) { doFetch(); return; }
+      timer = setTimeout(doFetch, 400);
+    }
+
+    return { fetchThreadsDebounced, results, getCallCount: () => callCount };
+  }
+
+  test("immediate mode fires synchronously without delay", () => {
+    const { fetchThreadsDebounced, getCallCount } = createDebouncedFetch();
+    fetchThreadsDebounced(true);
+    // Promise.resolve is microtask — flush it
+    expect(getCallCount()).toBe(1);
+  });
+
+  test("debounced calls collapse into one within the window", async () => {
+    const { fetchThreadsDebounced, results } = createDebouncedFetch();
+    fetchThreadsDebounced();
+    fetchThreadsDebounced();
+    fetchThreadsDebounced();
+
+    jest.advanceTimersByTime(400);
+    // Flush microtasks
+    await Promise.resolve();
+
+    expect(results).toHaveLength(1);
+  });
+
+  test("calls separated by more than 400ms each produce separate fetches", async () => {
+    const { fetchThreadsDebounced, results } = createDebouncedFetch();
+
+    fetchThreadsDebounced();
+    jest.advanceTimersByTime(400);
+    // Flush .then() and .finally() microtasks
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    fetchThreadsDebounced();
+    jest.advanceTimersByTime(400);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(results).toHaveLength(2);
+  });
+
+  test("in-flight dedup prevents concurrent requests", async () => {
+    let callCount = 0;
+    let resolveInFlight: (() => void) | null = null;
+    let inFlight: Promise<void> | null = null;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    function fetchThreadsDebounced(immediate = false) {
+      if (timer) clearTimeout(timer);
+      const doFetch = () => {
+        if (inFlight) return; // dedup
+        callCount++;
+        const p = new Promise<void>((resolve) => { resolveInFlight = resolve; })
+          .finally(() => { inFlight = null; });
+        inFlight = p;
+      };
+      if (immediate) { doFetch(); return; }
+      timer = setTimeout(doFetch, 400);
+    }
+
+    fetchThreadsDebounced(true); // starts first fetch
+    expect(callCount).toBe(1);
+
+    // While in-flight, another immediate call is skipped
+    fetchThreadsDebounced(true);
+    expect(callCount).toBe(1);
+
+    // Resolve in-flight, then next call goes through
+    resolveInFlight!();
+    await Promise.resolve();
+    fetchThreadsDebounced(true);
+    expect(callCount).toBe(2);
+  });
+
+  test("rapid events followed by settle produce exactly one fetch", async () => {
+    const { fetchThreadsDebounced, results } = createDebouncedFetch();
+
+    // Simulate rapid events: SSE done, approval-resolved, approval action
+    for (let i = 0; i < 10; i++) {
+      fetchThreadsDebounced();
+    }
+
+    jest.advanceTimersByTime(400);
+    await Promise.resolve();
+
+    expect(results).toHaveLength(1);
+  });
+
+  test("timer cleanup prevents stale fetch after unmount", () => {
+    const { fetchThreadsDebounced, results } = createDebouncedFetch();
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    // Simulate the component pattern: schedule then cleanup
+    const originalSetTimeout = globalThis.setTimeout;
+    const timerIds: ReturnType<typeof setTimeout>[] = [];
+    // Track timers
+    fetchThreadsDebounced(); // schedules a timer
+
+    // Simulate unmount cleanup
+    // In real code: clearTimeout(threadFetchTimerRef.current)
+    jest.clearAllTimers();
+
+    // Advance time — fetch should NOT fire
+    jest.advanceTimersByTime(1000);
+    expect(results).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Replace all bare `fetch('/api/threads')` calls in ChatPanel with a debounced + deduplicated `fetchThreadsDebounced()` function.

## Problem

Thread list was fetched via 4 separate call sites with no deduplication:
- Mount effect
- `approval-resolved` event handler
- After approval action (which also dispatches `approval-resolved`  double fetch)
- SSE `done` event

Rapid events (e.g. multiple approvals) could trigger concurrent racing fetches.

## Solution

- **400ms debounce window** collapses rapid invocations into a single fetch
- **In-flight dedup** skips new fetch if one is already pending
- **Immediate mode** for mount (no delay on initial page load)
- **Timer cleanup** on unmount prevents stale fetches

## Tests

- 10 new tests in `tests/unit/api/thread-fetch-debounce.test.ts`
  - 4 source code verification tests
  - 6 isolated debounce/dedup logic tests
- Full suite: 1216 tests across 95 suites  all passing

Closes #19