### PR TITLE
perf(PERF-08): Add pagination to listing queries

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -259,6 +259,8 @@ This ensures other HTTP requests (including new tabs, API calls, and the convers
 
 **Chat History Conversion** (`src/lib/agent/loop.ts`): `dbMessagesToChat()` converts DB messages to LLM-ready chat format. Previously it ran two full passes — first to collect `tool_call_id`s, then to build the result array, re-parsing `tool_calls` JSON each time. Now uses a single-pass approach with a pre-parsed `Map` cache, eliminating redundant `JSON.parse()` calls (50% reduction in parse overhead for tool-heavy conversations).
 
+**Listing Query Pagination** (`src/lib/db/queries.ts`): High-volume listing endpoints (`/api/threads`, `/api/knowledge`) use `LIMIT`/`OFFSET` pagination via `listThreadsPaginated()` and `listKnowledgePaginated()`. Each returns a `PaginatedResult<T>` with `{ data, total, limit, offset, hasMore }`. Threads default to 50 per page (max 200), knowledge to 100 per page (max 500). The frontend appends pages on demand via "Load more" controls. Original unpaginated functions (`listThreads()`, `listKnowledge()`) remain available for internal callers (e.g., export, migration).
+
 ### Notification & Inbound Email Safety Path
 
 - **Per-user thresholds** — Channel notifications are filtered by each user profile's `notification_level` (`low`, `medium`, `high`, `disaster`).

--- a/docs/TECH_SPECS.md
+++ b/docs/TECH_SPECS.md
@@ -265,10 +265,10 @@ The `app_config` table stores application-wide settings as key-value pairs. Sens
 
 | Method | Endpoint | Auth | Description |
 |--------|----------|------|-------------|
-| `GET/POST` | `/api/threads` | User | List/create threads (user-scoped) |
+| `GET/POST` | `/api/threads` | User | List/create threads (user-scoped); GET supports `?limit=N&offset=M` pagination (default 50, max 200) returning `{ data, total, limit, offset, hasMore }` |
 | `GET/DELETE` | `/api/threads/[threadId]` | User | Get/delete thread (ownership enforced) |
 | `POST` | `/api/threads/[threadId]/chat` | User | Send message and run agent loop (SSE streaming: `token`, `status`, `message`, `done`, `error` events) |
-| `GET/POST` | `/api/knowledge` | User | List/upsert knowledge entries (user-scoped) |
+| `GET/POST` | `/api/knowledge` | User | List/upsert knowledge entries (user-scoped); GET supports `?limit=N&offset=M` pagination (default 100, max 500) returning `{ data, total, limit, offset, hasMore }` |
 | `GET/POST` | `/api/mcp` | User | List/add MCP servers (global + user-scoped) |
 | `POST` | `/api/mcp/[serverId]/connect` | Auth | Connect to an MCP server |
 | `GET` | `/api/mcp/tools` | Auth | List all available MCP tools |
@@ -496,7 +496,7 @@ Each row reports topic rate and delta impact against overall rate.
 
 ### Coverage
 
-**1216 tests across 95 suites** — all passing.
+**1233 tests across 96 suites** — all passing.
 
 | Category | Suites | Description |
 |----------|--------|-------------|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexus-agent",
-  "version": "0.44.26",
+  "version": "0.44.27",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/scripts/smoke-test.js
+++ b/scripts/smoke-test.js
@@ -122,10 +122,10 @@ function cleanup() {
 // ── Tests ───────────────────────────────────────────────────────
 
 async function runTests() {
-  // 1. GET /api/threads — list threads
+  // 1. GET /api/threads — list threads (paginated response)
   const listRes = await httpRequest("GET", "/api/threads");
   check("GET /api/threads returns 200", listRes.status === 200);
-  check("GET /api/threads returns array", Array.isArray(listRes.body));
+  check("GET /api/threads returns array", Array.isArray(listRes.body && listRes.body.data));
 
   // 2. POST /api/threads — create a thread
   const createRes = await httpRequest("POST", "/api/threads", {

--- a/src/app/api/knowledge/route.ts
+++ b/src/app/api/knowledge/route.ts
@@ -1,13 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireUser } from "@/lib/auth/guard";
-import { listKnowledge, upsertKnowledge, updateKnowledge, deleteKnowledge, getKnowledgeEntry } from "@/lib/db";
+import { listKnowledgePaginated, upsertKnowledge, updateKnowledge, deleteKnowledge, getKnowledgeEntry } from "@/lib/db";
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   const auth = await requireUser();
   if ("error" in auth) return auth.error;
 
-  const knowledge = listKnowledge(auth.user.id);
-  return NextResponse.json(knowledge);
+  const url = req.nextUrl;
+  const limit = Math.min(Math.max(parseInt(url.searchParams.get("limit") || "100", 10) || 100, 1), 500);
+  const offset = Math.max(parseInt(url.searchParams.get("offset") || "0", 10) || 0, 0);
+
+  const result = listKnowledgePaginated(auth.user.id, limit, offset);
+  return NextResponse.json(result);
 }
 
 export async function POST(req: NextRequest) {

--- a/src/app/api/threads/route.ts
+++ b/src/app/api/threads/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireUser } from "@/lib/auth/guard";
-import { listThreads, createThread, addLog } from "@/lib/db";
+import { listThreadsPaginated, createThread, addLog } from "@/lib/db";
 import { initializeDatabase } from "@/lib/db";
 
 // Ensure DB is initialized
@@ -16,14 +16,17 @@ try {
   });
 }
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   try {
     const auth = await requireUser();
     if ("error" in auth) return auth.error;
 
-    const threads = listThreads(auth.user.id);
-    // PERF-20: Removed verbose read-path logging (was 3,600+ log writes/hour)
-    return NextResponse.json(threads);
+    const url = req.nextUrl;
+    const limit = Math.min(Math.max(parseInt(url.searchParams.get("limit") || "50", 10) || 50, 1), 200);
+    const offset = Math.max(parseInt(url.searchParams.get("offset") || "0", 10) || 0, 0);
+
+    const result = listThreadsPaginated(auth.user.id, limit, offset);
+    return NextResponse.json(result);
   } catch (err) {
     addLog({
       level: "error",

--- a/src/components/chat-panel.tsx
+++ b/src/components/chat-panel.tsx
@@ -132,6 +132,8 @@ function sanitizeAssistantContent(content: string | null, hasAttachments: boolea
 
 export function ChatPanel() {
   const [threads, setThreads] = useState<Thread[]>([]);
+  const [threadsTotal, setThreadsTotal] = useState(0);
+  const [threadsHasMore, setThreadsHasMore] = useState(false);
   const [activeThread, setActiveThread] = useState<string | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
@@ -155,7 +157,13 @@ export function ChatPanel() {
       if (threadFetchInFlightRef.current) return; // already in-flight — skip
       const p = fetch("/api/threads")
         .then((r) => r.json())
-        .then((d) => { if (Array.isArray(d)) setThreads(d); })
+        .then((d) => {
+          if (d && Array.isArray(d.data)) {
+            setThreads(d.data);
+            setThreadsTotal(d.total ?? d.data.length);
+            setThreadsHasMore(d.hasMore ?? false);
+          }
+        })
         .catch(console.error)
         .finally(() => { threadFetchInFlightRef.current = null; });
       threadFetchInFlightRef.current = p;
@@ -1134,6 +1142,27 @@ export function ChatPanel() {
               </ListItemButton>
             ))}
           </List>
+          {threadsHasMore && (
+            <Box sx={{ textAlign: "center", py: 1 }}>
+              <Button
+                size="small"
+                onClick={() => {
+                  fetch(`/api/threads?limit=50&offset=${threads.length}`)
+                    .then((r) => r.json())
+                    .then((d) => {
+                      if (d && Array.isArray(d.data)) {
+                        setThreads((prev) => [...prev, ...d.data]);
+                        setThreadsTotal(d.total ?? threads.length + d.data.length);
+                        setThreadsHasMore(d.hasMore ?? false);
+                      }
+                    })
+                    .catch(console.error);
+                }}
+              >
+                Load more ({threadsTotal - threads.length} remaining)
+              </Button>
+            </Box>
+          )}
         </Box>
       </Paper>
 

--- a/src/components/knowledge-vault.tsx
+++ b/src/components/knowledge-vault.tsx
@@ -31,6 +31,8 @@ function getSourceLabel(sourceContext: string | null): string {
 
 export function KnowledgeVault() {
   const [entries, setEntries] = useState<KnowledgeEntry[]>([]);
+  const [knowledgeTotal, setKnowledgeTotal] = useState(0);
+  const [knowledgeHasMore, setKnowledgeHasMore] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editValue, setEditValue] = useState("");
   const [sourceFilter, setSourceFilter] = useState<SourceFilter>("all");
@@ -41,7 +43,26 @@ export function KnowledgeVault() {
   const fetchKnowledge = () => {
     fetch("/api/knowledge")
       .then((r) => r.json())
-      .then((d) => { if (Array.isArray(d)) setEntries(d); })
+      .then((d) => {
+        if (d && Array.isArray(d.data)) {
+          setEntries(d.data);
+          setKnowledgeTotal(d.total ?? d.data.length);
+          setKnowledgeHasMore(d.hasMore ?? false);
+        }
+      })
+      .catch(console.error);
+  };
+
+  const loadMoreKnowledge = () => {
+    fetch(`/api/knowledge?limit=100&offset=${entries.length}`)
+      .then((r) => r.json())
+      .then((d) => {
+        if (d && Array.isArray(d.data)) {
+          setEntries((prev) => [...prev, ...d.data]);
+          setKnowledgeTotal(d.total ?? entries.length + d.data.length);
+          setKnowledgeHasMore(d.hasMore ?? false);
+        }
+      })
       .catch(console.error);
   };
 
@@ -255,6 +276,17 @@ export function KnowledgeVault() {
                 onClick={() => setRenderCount((prev) => prev + 120)}
               >
                 Load more ({filteredEntries.length - visibleEntries.length} remaining)
+              </MuiButton>
+            </Box>
+          )}
+          {knowledgeHasMore && filteredEntries.length <= visibleEntries.length && (
+            <Box sx={{ p: 1.5, display: "flex", justifyContent: "center" }}>
+              <MuiButton
+                size="small"
+                variant="outlined"
+                onClick={loadMoreKnowledge}
+              >
+                Load more from server ({knowledgeTotal - entries.length} remaining)
               </MuiButton>
             </Box>
           )}

--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -8,6 +8,15 @@ import { appCache, CACHE_KEYS } from "@/lib/cache";
 /** Thin wrapper that passes the (patchable) `getDb` import to the cache */
 function stmt(sql: string) { return _cachedStmt(sql, getDb); }
 
+/** Generic paginated result wrapper */
+export interface PaginatedResult<T> {
+  data: T[];
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+}
+
 // â”€â”€â”€ Users â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 export interface UserRecord {
@@ -659,6 +668,16 @@ export function listKnowledge(userId?: string): KnowledgeEntry[] {
     .all(userId) as KnowledgeEntry[];
 }
 
+export function listKnowledgePaginated(userId: string, limit = 100, offset = 0): PaginatedResult<KnowledgeEntry> {
+  const db = getDb();
+  const total = (db.prepare("SELECT COUNT(*) as cnt FROM user_knowledge WHERE user_id = ? OR user_id IS NULL")
+    .get(userId) as { cnt: number }).cnt;
+  const data = db.prepare(
+    "SELECT * FROM user_knowledge WHERE user_id = ? OR user_id IS NULL ORDER BY last_updated DESC LIMIT ? OFFSET ?"
+  ).all(userId, limit, offset) as KnowledgeEntry[];
+  return { data, total, limit, offset, hasMore: offset + data.length < total };
+}
+
 export function getKnowledgeEntry(id: number): KnowledgeEntry | undefined {
   return stmt(
     "SELECT * FROM user_knowledge WHERE id = ?"
@@ -782,6 +801,18 @@ export function listThreads(userId?: string): Thread[] {
   return getDb()
     .prepare("SELECT * FROM threads WHERE title NOT LIKE '[proactive-scan]%' AND title NOT LIKE '[scheduled]%' AND title NOT LIKE 'channel:%' ORDER BY last_message_at DESC")
     .all() as Thread[];
+}
+
+const THREAD_FILTER = "title NOT LIKE '[proactive-scan]%' AND title NOT LIKE '[scheduled]%' AND title NOT LIKE 'channel:%'";
+
+export function listThreadsPaginated(userId: string, limit = 50, offset = 0): PaginatedResult<Thread> {
+  const db = getDb();
+  const total = (db.prepare(`SELECT COUNT(*) as cnt FROM threads WHERE user_id = ? AND ${THREAD_FILTER}`)
+    .get(userId) as { cnt: number }).cnt;
+  const data = db.prepare(
+    `SELECT * FROM threads WHERE user_id = ? AND ${THREAD_FILTER} ORDER BY last_message_at DESC LIMIT ? OFFSET ?`
+  ).all(userId, limit, offset) as Thread[];
+  return { data, total, limit, offset, hasMore: offset + data.length < total };
 }
 
 export function getThread(id: string): Thread | undefined {

--- a/tests/component/component-render.test.tsx
+++ b/tests/component/component-render.test.tsx
@@ -336,7 +336,7 @@ describe("KnowledgeVault", () => {
       if (url.includes("/api/knowledge")) {
         return Promise.resolve({
           ok: true,
-          json: () => Promise.resolve([]),
+          json: () => Promise.resolve({ data: [], total: 0, limit: 100, offset: 0, hasMore: false }),
         });
       }
       return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });

--- a/tests/integration/api/knowledge.test.ts
+++ b/tests/integration/api/knowledge.test.ts
@@ -21,15 +21,17 @@ afterAll(() => teardownTestDb());
 describe("GET /api/knowledge", () => {
   test("returns 401 when unauthenticated", async () => {
     setMockUser(null);
-    const res = await GET();
+    const res = await GET(new NextRequest("http://localhost/api/knowledge"));
     expect(res.status).toBe(401);
   });
 
   test("returns empty list initially", async () => {
     setMockUser({ id: userId, email: "know@example.com", role: "user" });
-    const res = await GET();
-    const data = await res.json();
-    expect(data).toEqual([]);
+    const res = await GET(new NextRequest("http://localhost/api/knowledge"));
+    const body = await res.json();
+    expect(body.data).toEqual([]);
+    expect(body.total).toBe(0);
+    expect(body.hasMore).toBe(false);
   });
 });
 
@@ -63,17 +65,17 @@ describe("POST /api/knowledge", () => {
 
   test("created entry appears in GET", async () => {
     setMockUser({ id: userId, email: "know@example.com", role: "user" });
-    const res = await GET();
-    const data = await res.json();
-    expect(data.length).toBe(1);
-    expect(data[0].entity).toBe("TypeScript");
+    const res = await GET(new NextRequest("http://localhost/api/knowledge"));
+    const body = await res.json();
+    expect(body.data.length).toBe(1);
+    expect(body.data[0].entity).toBe("TypeScript");
   });
 
   test("entries are scoped to user", async () => {
     setMockUser({ id: otherUserId, email: "other@example.com", role: "user" });
-    const res = await GET();
-    const data = await res.json();
-    expect(data).toEqual([]);
+    const res = await GET(new NextRequest("http://localhost/api/knowledge"));
+    const body = await res.json();
+    expect(body.data).toEqual([]);
   });
 });
 
@@ -82,9 +84,9 @@ describe("PUT /api/knowledge", () => {
 
   beforeAll(async () => {
     setMockUser({ id: userId, email: "know@example.com", role: "user" });
-    const res = await GET();
-    const data = await res.json();
-    entryId = data[0].id;
+    const res = await GET(new NextRequest("http://localhost/api/knowledge"));
+    const body = await res.json();
+    entryId = body.data[0].id;
   });
 
   test("returns 400 without id", async () => {
@@ -126,9 +128,9 @@ describe("DELETE /api/knowledge", () => {
 
   beforeAll(async () => {
     setMockUser({ id: userId, email: "know@example.com", role: "user" });
-    const res = await GET();
-    const data = await res.json();
-    entryId = data[0].id;
+    const res = await GET(new NextRequest("http://localhost/api/knowledge"));
+    const body = await res.json();
+    entryId = body.data[0].id;
   });
 
   test("returns 400 without id", async () => {
@@ -156,8 +158,8 @@ describe("DELETE /api/knowledge", () => {
 
   test("entry gone after deletion", async () => {
     setMockUser({ id: userId, email: "know@example.com", role: "user" });
-    const res = await GET();
-    const data = await res.json();
-    expect(data).toEqual([]);
+    const res = await GET(new NextRequest("http://localhost/api/knowledge"));
+    const body = await res.json();
+    expect(body.data).toEqual([]);
   });
 });

--- a/tests/integration/api/threads.test.ts
+++ b/tests/integration/api/threads.test.ts
@@ -31,16 +31,18 @@ afterAll(() => teardownTestDb());
 describe("GET /api/threads", () => {
   test("returns 401 when unauthenticated", async () => {
     setMockUser(null);
-    const res = await GET();
+    const res = await GET(new NextRequest("http://localhost/api/threads"));
     expect(res.status).toBe(401);
   });
 
   test("returns empty list for new user", async () => {
     setMockUser({ id: userId, email: "threads@example.com", role: "user" });
-    const res = await GET();
+    const res = await GET(new NextRequest("http://localhost/api/threads"));
     expect(res.status).toBe(200);
-    const data = await res.json();
-    expect(data).toEqual([]);
+    const body = await res.json();
+    expect(body.data).toEqual([]);
+    expect(body.total).toBe(0);
+    expect(body.hasMore).toBe(false);
   });
 });
 
@@ -61,17 +63,17 @@ describe("POST /api/threads", () => {
 
   test("created thread appears in GET list", async () => {
     setMockUser({ id: userId, email: "threads@example.com", role: "user" });
-    const res = await GET();
-    const data = await res.json();
-    expect(data.length).toBeGreaterThanOrEqual(1);
-    expect(data[0].title).toBe("My thread");
+    const res = await GET(new NextRequest("http://localhost/api/threads"));
+    const body = await res.json();
+    expect(body.data.length).toBeGreaterThanOrEqual(1);
+    expect(body.data[0].title).toBe("My thread");
   });
 
   test("user cannot see another user's threads", async () => {
     setMockUser({ id: adminId, email: "admin@example.com", role: "admin" });
-    const res = await GET();
-    const data = await res.json();
-    expect(data).toEqual([]);
+    const res = await GET(new NextRequest("http://localhost/api/threads"));
+    const body = await res.json();
+    expect(body.data).toEqual([]);
   });
 });
 
@@ -165,9 +167,9 @@ describe("GET /api/threads — logging", () => {
     ).length;
 
     // Make several GET requests
-    await GET();
-    await GET();
-    await GET();
+    await GET(new NextRequest("http://localhost/api/threads"));
+    await GET(new NextRequest("http://localhost/api/threads"));
+    await GET(new NextRequest("http://localhost/api/threads"));
 
     // Count again — should NOT have increased
     const logsAfter = getRecentLogs(10000);

--- a/tests/unit/db/pagination.test.ts
+++ b/tests/unit/db/pagination.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit tests — Pagination for listing queries (PERF-08)
+ */
+import { setupTestDb, teardownTestDb, seedTestUser } from "../../helpers/test-db";
+import {
+  createThread,
+  listThreadsPaginated,
+  listKnowledgePaginated,
+  upsertKnowledge,
+} from "@/lib/db/queries";
+
+let userId: string;
+
+beforeAll(() => {
+  setupTestDb();
+  userId = seedTestUser({ email: "pagination@example.com" });
+});
+afterAll(() => teardownTestDb());
+
+describe("listThreadsPaginated", () => {
+  beforeAll(() => {
+    // Create 15 threads for pagination tests
+    for (let i = 0; i < 15; i++) {
+      createThread(`Thread ${String(i).padStart(2, "0")}`, userId);
+    }
+  });
+
+  test("returns paginated result with correct shape", () => {
+    const result = listThreadsPaginated(userId, 10, 0);
+    expect(result).toHaveProperty("data");
+    expect(result).toHaveProperty("total");
+    expect(result).toHaveProperty("limit");
+    expect(result).toHaveProperty("offset");
+    expect(result).toHaveProperty("hasMore");
+    expect(Array.isArray(result.data)).toBe(true);
+  });
+
+  test("respects limit parameter", () => {
+    const result = listThreadsPaginated(userId, 5, 0);
+    expect(result.data.length).toBe(5);
+    expect(result.limit).toBe(5);
+  });
+
+  test("respects offset parameter", () => {
+    const page1 = listThreadsPaginated(userId, 5, 0);
+    const page2 = listThreadsPaginated(userId, 5, 5);
+    expect(page1.data[0].id).not.toBe(page2.data[0].id);
+    expect(page2.offset).toBe(5);
+  });
+
+  test("hasMore is true when more results exist", () => {
+    const result = listThreadsPaginated(userId, 5, 0);
+    expect(result.hasMore).toBe(true);
+    expect(result.total).toBeGreaterThan(5);
+  });
+
+  test("hasMore is false on last page", () => {
+    const result = listThreadsPaginated(userId, 100, 0);
+    expect(result.hasMore).toBe(false);
+    expect(result.data.length).toBe(result.total);
+  });
+
+  test("total count is consistent across pages", () => {
+    const page1 = listThreadsPaginated(userId, 5, 0);
+    const page2 = listThreadsPaginated(userId, 5, 5);
+    expect(page1.total).toBe(page2.total);
+  });
+
+  test("default limit is 50", () => {
+    const result = listThreadsPaginated(userId);
+    expect(result.limit).toBe(50);
+  });
+
+  test("excludes proactive-scan, scheduled, and channel threads", () => {
+    createThread("[proactive-scan] test", userId);
+    createThread("[scheduled] test", userId);
+    createThread("channel:test:test", userId);
+    const result = listThreadsPaginated(userId, 200, 0);
+    expect(result.data.every((t) => !t.title?.startsWith("[proactive-scan]"))).toBe(true);
+    expect(result.data.every((t) => !t.title?.startsWith("[scheduled]"))).toBe(true);
+    expect(result.data.every((t) => !t.title?.startsWith("channel:"))).toBe(true);
+  });
+
+  test("offset beyond total returns empty data", () => {
+    const result = listThreadsPaginated(userId, 50, 9999);
+    expect(result.data.length).toBe(0);
+    expect(result.hasMore).toBe(false);
+    expect(result.total).toBeGreaterThan(0);
+  });
+});
+
+describe("listKnowledgePaginated", () => {
+  beforeAll(() => {
+    // Create 25 knowledge entries for pagination tests
+    for (let i = 0; i < 25; i++) {
+      upsertKnowledge({
+        user_id: userId,
+        entity: `Entity ${i}`,
+        attribute: `attr_${i}`,
+        value: `Value ${i}`,
+        source_context: null,
+      }, userId);
+    }
+  });
+
+  test("returns paginated result with correct shape", () => {
+    const result = listKnowledgePaginated(userId, 10, 0);
+    expect(result).toHaveProperty("data");
+    expect(result).toHaveProperty("total");
+    expect(result).toHaveProperty("limit");
+    expect(result).toHaveProperty("offset");
+    expect(result).toHaveProperty("hasMore");
+    expect(Array.isArray(result.data)).toBe(true);
+  });
+
+  test("respects limit and offset", () => {
+    const page1 = listKnowledgePaginated(userId, 10, 0);
+    const page2 = listKnowledgePaginated(userId, 10, 10);
+    expect(page1.data.length).toBe(10);
+    expect(page2.data.length).toBe(10);
+    expect(page1.data[0].id).not.toBe(page2.data[0].id);
+  });
+
+  test("hasMore is correct", () => {
+    const small = listKnowledgePaginated(userId, 5, 0);
+    expect(small.hasMore).toBe(true);
+
+    const all = listKnowledgePaginated(userId, 500, 0);
+    expect(all.hasMore).toBe(false);
+  });
+
+  test("default limit is 100", () => {
+    const result = listKnowledgePaginated(userId);
+    expect(result.limit).toBe(100);
+  });
+
+  test("total count is accurate", () => {
+    const result = listKnowledgePaginated(userId, 1, 0);
+    expect(result.total).toBe(25);
+  });
+});
+
+describe("API response format verification (source code)", () => {
+  const fs = require("fs");
+  const path = require("path");
+
+  test("threads route uses listThreadsPaginated", () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, "../../../src/app/api/threads/route.ts"),
+      "utf-8"
+    );
+    expect(src).toContain("listThreadsPaginated");
+    expect(src).toContain("limit");
+    expect(src).toContain("offset");
+  });
+
+  test("knowledge route uses listKnowledgePaginated", () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, "../../../src/app/api/knowledge/route.ts"),
+      "utf-8"
+    );
+    expect(src).toContain("listKnowledgePaginated");
+    expect(src).toContain("limit");
+    expect(src).toContain("offset");
+  });
+
+  test("smoke test checks paginated format", () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, "../../../scripts/smoke-test.js"),
+      "utf-8"
+    );
+    expect(src).toContain("listRes.body.data");
+  });
+});


### PR DESCRIPTION
Closes #9

## Changes
- **DB layer**: Added \PaginatedResult<T>\ interface, \listThreadsPaginated()\ and \listKnowledgePaginated()\ functions with COUNT + LIMIT/OFFSET queries
- **API routes**: \GET /api/threads\ and \GET /api/knowledge\ accept \?limit=N&offset=M\, return \{ data, total, limit, offset, hasMore }\
  - Threads: default 50/page, max 200
  - Knowledge: default 100/page, max 500
- **Frontend**: Load more buttons in thread sidebar and knowledge vault
- **Tests**: 17 new pagination unit tests; updated integration tests for paginated response format
- **Docs**: Updated ARCHITECTURE.md and TECH_SPECS.md

## Verification
- 1233 tests across 96 suites  all passing
- 0 vulnerabilities (npm audit)