### PR TITLE
perf(PERF-09): Implement worker thread pool

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -261,6 +261,8 @@ This ensures other HTTP requests (including new tabs, API calls, and the convers
 
 **Listing Query Pagination** (`src/lib/db/queries.ts`): High-volume listing endpoints (`/api/threads`, `/api/knowledge`) use `LIMIT`/`OFFSET` pagination via `listThreadsPaginated()` and `listKnowledgePaginated()`. Each returns a `PaginatedResult<T>` with `{ data, total, limit, offset, hasMore }`. Threads default to 50 per page (max 200), knowledge to 100 per page (max 500). The frontend appends pages on demand via "Load more" controls. Original unpaginated functions (`listThreads()`, `listKnowledge()`) remain available for internal callers (e.g., export, migration).
 
+**Worker Thread Pool** (`src/lib/agent/worker-manager.ts`): LLM API calls are offloaded to a reusable pool of worker threads instead of spawning a new thread per request. Pool size is configurable via `WORKER_POOL_SIZE` env var (default 2, range 1–8). Workers are recycled after each task completes — the worker script (`scripts/agent-worker.js`) resets `aborted` and `toolResultResolvers` state between tasks. If all workers are busy, tasks are queued and dispatched as workers become idle (30s queue timeout). Crashed workers are automatically terminated, replaced, and logged. `getWorkerPoolStats()` exposes pool diagnostics (busy/idle counts, queue length).
+
 ### Notification & Inbound Email Safety Path
 
 - **Per-user thresholds** — Channel notifications are filtered by each user profile's `notification_level` (`low`, `medium`, `high`, `disaster`).

--- a/docs/TECH_SPECS.md
+++ b/docs/TECH_SPECS.md
@@ -496,7 +496,7 @@ Each row reports topic rate and delta impact against overall rate.
 
 ### Coverage
 
-**1233 tests across 96 suites** — all passing.
+**1242 tests across 96 suites** — all passing.
 
 | Category | Suites | Description |
 |----------|--------|-------------|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexus-agent",
-  "version": "0.44.27",
+  "version": "0.44.28",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/scripts/agent-worker.js
+++ b/scripts/agent-worker.js
@@ -93,6 +93,10 @@ parentPort.on('message', async (msg) => {
 /* ── Initialise LLM client and run the loop ──────────────────────── */
 
 async function handleStart(config) {
+  // Reset state for worker reuse (pool keeps workers alive between tasks)
+  aborted = false;
+  toolResultResolvers.clear();
+
   const {
     providerType,
     apiKey,
@@ -209,7 +213,10 @@ async function runLoop(client, isAnthropic, model, config) {
 
       // Block (async) until main thread executes the tools and responds
       const results = await waitForToolResults(requestId);
-      if (aborted) return;
+      if (aborted) {
+        parentPort.postMessage({ type: 'error', data: 'Aborted' });
+        return;
+      }
 
       for (const r of results) {
         chatMessages.push({

--- a/src/lib/agent/index.ts
+++ b/src/lib/agent/index.ts
@@ -1,6 +1,6 @@
 export { runAgentLoop, continueAgentLoop, type AgentResponse } from "./loop";
 export { runAgentLoopWithWorker } from "./loop-worker";
-export { isWorkerAvailable } from "./worker-manager";
+export { isWorkerAvailable, getWorkerPoolStats } from "./worker-manager";
 export { executeWithGatekeeper, executeApprovedTool, type GatekeeperResult } from "./gatekeeper";
 export { BUILTIN_WEB_TOOLS, isBuiltinWebTool, executeBuiltinWebTool } from "./web-tools";
 export { BUILTIN_BROWSER_TOOLS, isBrowserTool, executeBrowserTool, BROWSER_TOOLS_REQUIRING_APPROVAL } from "./browser-tools";

--- a/src/lib/agent/worker-manager.ts
+++ b/src/lib/agent/worker-manager.ts
@@ -74,21 +74,302 @@ export function isWorkerAvailable(): boolean {
   return _workerAvailable!;
 }
 
-/* ── Run a single LLM session in a worker thread ───────────────────── */
+/* ── Worker Pool ────────────────────────────────────────────────────── */
+
+interface PooledWorker {
+  worker: Worker;
+  busy: boolean;
+  task: TaskBinding | null;
+}
+
+interface TaskBinding {
+  settled: boolean;
+  resolve: (result: WorkerDoneResult) => void;
+  reject: (error: Error) => void;
+  onToken?: OnTokenFn;
+  onStatus?: OnStatusFn;
+  onToolRequest?: OnToolRequestFn;
+  timeout: ReturnType<typeof setTimeout>;
+  handle: TaskHandle;
+}
+
+interface QueuedTask {
+  config: WorkerStartConfig;
+  onToken?: OnTokenFn;
+  onStatus?: OnStatusFn;
+  onToolRequest?: OnToolRequestFn;
+  resolve: (result: WorkerDoneResult) => void;
+  reject: (error: Error) => void;
+  handle: TaskHandle;
+  queueTimer: ReturnType<typeof setTimeout>;
+}
+
+interface TaskHandle {
+  state: "queued" | "dispatched" | "settled";
+  pw: PooledWorker | null;
+}
+
+const POOL_SIZE = Math.min(
+  Math.max(parseInt(process.env.WORKER_POOL_SIZE || "2", 10) || 2, 1),
+  8
+);
+
+const pool: PooledWorker[] = [];
+const taskQueue: QueuedTask[] = [];
+let poolInitialized = false;
+
+function ensurePool(): void {
+  if (poolInitialized) return;
+  poolInitialized = true;
+  for (let i = 0; i < POOL_SIZE; i++) {
+    try {
+      pool.push(spawnPooledWorker());
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      addLog({
+        level: "error",
+        source: "worker-pool",
+        message: `Failed to create pool worker ${i}: ${msg}`,
+        metadata: null,
+      });
+    }
+  }
+  if (pool.length > 0) {
+    addLog({
+      level: "info",
+      source: "worker-pool",
+      message: `Worker pool initialized with ${pool.length} thread(s)`,
+      metadata: null,
+    });
+  }
+}
+
+function spawnPooledWorker(): PooledWorker {
+  const worker = new Worker(WORKER_SCRIPT);
+  const pw: PooledWorker = { worker, busy: false, task: null };
+
+  worker.on("message", async (msg: {
+    type: string;
+    data?: unknown;
+    requestId?: string;
+    calls?: ToolCall[];
+    assistantContent?: string | null;
+  }) => {
+    await handlePoolMessage(pw, msg);
+  });
+
+  worker.on("error", (err: Error) => handlePoolError(pw, err));
+  worker.on("exit", (code: number) => handlePoolExit(pw, code));
+
+  return pw;
+}
+
+async function handlePoolMessage(pw: PooledWorker, msg: {
+  type: string;
+  data?: unknown;
+  requestId?: string;
+  calls?: ToolCall[];
+  assistantContent?: string | null;
+}) {
+  const task = pw.task;
+  if (!task || task.settled) return;
+
+  try {
+    switch (msg.type) {
+      case "token":
+        await task.onToken?.(msg.data as string);
+        break;
+
+      case "status":
+        task.onStatus?.(msg.data as { step: string; detail?: string });
+        break;
+
+      case "tool_request": {
+        if (!task.onToolRequest) {
+          pw.worker.postMessage({
+            type: "tool_result",
+            requestId: msg.requestId,
+            results: (msg.calls || []).map((tc: ToolCall) => ({
+              toolCallId: tc.id,
+              toolName: tc.name,
+              content: JSON.stringify({ error: "Tool execution not available" }),
+            })),
+          });
+          break;
+        }
+        const results = await task.onToolRequest(
+          msg.calls || [],
+          msg.assistantContent ?? null
+        );
+        pw.worker.postMessage({
+          type: "tool_result",
+          requestId: msg.requestId,
+          results,
+        });
+        break;
+      }
+
+      case "done":
+        settleTask(pw, () => task.resolve(msg.data as WorkerDoneResult));
+        break;
+
+      case "error":
+        settleTask(pw, () => task.reject(new Error(msg.data as string)));
+        break;
+    }
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    settleTask(pw, () =>
+      task.reject(new Error(`Worker message handler error: ${errMsg}`))
+    );
+  }
+}
+
+function handlePoolError(pw: PooledWorker, err: Error) {
+  if (pw.task && !pw.task.settled) {
+    const reject = pw.task.reject;
+    settleTask(pw, () => reject(err), true);
+  }
+  replaceWorker(pw);
+}
+
+function handlePoolExit(pw: PooledWorker, code: number) {
+  if (pw.task && !pw.task.settled) {
+    const reject = pw.task.reject;
+    settleTask(
+      pw,
+      () =>
+        reject(
+          new Error(
+            code !== 0
+              ? `Agent worker exited with code ${code}`
+              : "Agent worker exited before completing"
+          )
+        ),
+      true
+    );
+  }
+  replaceWorker(pw);
+}
+
+function settleTask(pw: PooledWorker, fn: () => void, skipRelease = false) {
+  const task = pw.task;
+  if (!task || task.settled) return;
+  task.settled = true;
+  task.handle.state = "settled";
+  clearTimeout(task.timeout);
+  pw.task = null;
+  pw.busy = false;
+  fn();
+  if (!skipRelease) drainQueue();
+}
+
+function replaceWorker(pw: PooledWorker) {
+  const idx = pool.indexOf(pw);
+  if (idx === -1) return;
+  try {
+    pw.worker.terminate();
+  } catch {
+    /* already exited */
+  }
+  try {
+    pool[idx] = spawnPooledWorker();
+    addLog({
+      level: "warn",
+      source: "worker-pool",
+      message: "Worker crashed and was replaced",
+      metadata: null,
+    });
+  } catch (err) {
+    pool.splice(idx, 1);
+    const msg = err instanceof Error ? err.message : String(err);
+    addLog({
+      level: "error",
+      source: "worker-pool",
+      message: `Failed to replace worker: ${msg}`,
+      metadata: null,
+    });
+  }
+  drainQueue();
+}
+
+function drainQueue() {
+  while (taskQueue.length > 0) {
+    const idle = pool.find((w) => !w.busy);
+    if (!idle) break;
+    const queued = taskQueue.shift()!;
+    clearTimeout(queued.queueTimer);
+    if (queued.handle.state === "settled") continue;
+    assignTask(
+      idle,
+      queued.config,
+      queued.onToken,
+      queued.onStatus,
+      queued.onToolRequest,
+      queued.resolve,
+      queued.reject,
+      queued.handle
+    );
+  }
+}
+
+function assignTask(
+  pw: PooledWorker,
+  config: WorkerStartConfig,
+  onToken: OnTokenFn | undefined,
+  onStatus: OnStatusFn | undefined,
+  onToolRequest: OnToolRequestFn | undefined,
+  resolve: (r: WorkerDoneResult) => void,
+  reject: (e: Error) => void,
+  handle: TaskHandle
+) {
+  pw.busy = true;
+  handle.state = "dispatched";
+  handle.pw = pw;
+
+  const timeout = setTimeout(() => {
+    settleTask(pw, () => reject(new Error("Agent worker timed out after 30s")), true);
+    replaceWorker(pw);
+  }, 30_000);
+
+  pw.task = {
+    settled: false,
+    resolve,
+    reject,
+    onToken,
+    onStatus,
+    onToolRequest,
+    timeout,
+    handle,
+  };
+
+  pw.worker.postMessage({
+    type: "start",
+    config: {
+      providerType: config.provider.providerType,
+      apiKey: config.provider.apiKey,
+      model: config.provider.model,
+      endpoint: config.provider.endpoint,
+      deployment: config.provider.deployment,
+      apiVersion: config.provider.apiVersion,
+      baseURL: config.provider.baseURL,
+      disableThinking: config.provider.disableThinking,
+      systemPrompt: config.systemPrompt,
+      messages: config.messages,
+      tools: config.tools,
+      maxIterations: config.maxIterations || 25,
+    },
+  });
+}
+
+/* ── Run a single LLM session via the worker pool ──────────────────── */
 
 /**
- * Spawn a worker thread to handle LLM communication.
+ * Run an LLM session using a pooled worker thread.
  *
- * Returns a Promise that resolves with the final response, or rejects
- * on error.  The worker is transient — created per request and terminated
- * after the response is complete.
- *
- * @param config       Provider + prompt + messages + tools
- * @param onToken      Called for each streamed LLM token
- * @param onStatus     Called for status updates (model selection, iterations)
- * @param onToolRequest Called when the LLM wants to execute tools.
- *                      The callback must execute them (in the main thread)
- *                      and return the results.
+ * Workers are reused across requests (pool size controlled by
+ * WORKER_POOL_SIZE env var, default 2, max 8).  If all workers are busy,
+ * the task is queued and dispatched when one becomes idle.
  */
 export function runLlmInWorker(
   config: WorkerStartConfig,
@@ -96,158 +377,88 @@ export function runLlmInWorker(
   onStatus?: OnStatusFn,
   onToolRequest?: OnToolRequestFn
 ): { promise: Promise<WorkerDoneResult>; abort: () => void } {
-  let worker: Worker | null = null;
-  let settled = false;
+  ensurePool();
+
+  const handle: TaskHandle = { state: "queued", pw: null };
+  let queuedEntry: QueuedTask | null = null;
 
   const promise = new Promise<WorkerDoneResult>((resolve, reject) => {
-    try {
-      worker = new Worker(WORKER_SCRIPT);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      addLog({
-        level: "error",
-        source: "worker",
-        message: `Failed to spawn agent worker: ${msg}`,
-        metadata: null,
-      });
-      reject(new Error(`Worker spawn failed: ${msg}`));
-      return;
+    const idle = pool.find((w) => !w.busy);
+    if (idle) {
+      assignTask(idle, config, onToken, onStatus, onToolRequest, resolve, reject, handle);
+    } else {
+      const queueTimer = setTimeout(() => {
+        const idx = taskQueue.indexOf(queuedEntry!);
+        if (idx !== -1) taskQueue.splice(idx, 1);
+        if (handle.state !== "settled") {
+          handle.state = "settled";
+          reject(new Error("Worker pool queue timeout — all workers busy for 30s"));
+        }
+      }, 30_000);
+
+      queuedEntry = {
+        config,
+        onToken,
+        onStatus,
+        onToolRequest,
+        resolve,
+        reject,
+        handle,
+        queueTimer,
+      };
+      taskQueue.push(queuedEntry);
     }
-
-    const settle = (fn: () => void) => {
-      if (settled) return;
-      settled = true;
-      fn();
-    };
-
-    // Hard timeout: 30 seconds — if the worker hasn't responded by then,
-    // kill it and fall back to main thread (which has its own fallback logic)
-    const timeout = setTimeout(() => {
-      settle(() => {
-        worker?.terminate();
-        reject(new Error("Agent worker timed out after 30s"));
-      });
-    }, 30_000);
-
-    worker.on("message", async (msg: {
-      type: string;
-      data?: unknown;
-      requestId?: string;
-      calls?: ToolCall[];
-      assistantContent?: string | null;
-    }) => {
-      try {
-        switch (msg.type) {
-          case "token":
-            await onToken?.(msg.data as string);
-            break;
-
-          case "status":
-            onStatus?.(msg.data as { step: string; detail?: string });
-            break;
-
-          case "tool_request": {
-            if (!onToolRequest) {
-              // No tool handler — send empty results
-              worker?.postMessage({
-                type: "tool_result",
-                requestId: msg.requestId,
-                results: (msg.calls || []).map((tc: ToolCall) => ({
-                  toolCallId: tc.id,
-                  toolName: tc.name,
-                  content: JSON.stringify({ error: "Tool execution not available" }),
-                })),
-              });
-              break;
-            }
-            const results = await onToolRequest(
-              msg.calls || [],
-              msg.assistantContent ?? null
-            );
-            worker?.postMessage({
-              type: "tool_result",
-              requestId: msg.requestId,
-              results,
-            });
-            break;
-          }
-
-          case "done":
-            clearTimeout(timeout);
-            settle(() => {
-              worker?.terminate();
-              resolve(msg.data as WorkerDoneResult);
-            });
-            break;
-
-          case "error":
-            clearTimeout(timeout);
-            settle(() => {
-              worker?.terminate();
-              reject(new Error(msg.data as string));
-            });
-            break;
-        }
-      } catch (err) {
-        clearTimeout(timeout);
-        const errMsg = err instanceof Error ? err.message : String(err);
-        settle(() => {
-          worker?.terminate();
-          reject(new Error(`Worker message handler error: ${errMsg}`));
-        });
-      }
-    });
-
-    worker.on("error", (err) => {
-      clearTimeout(timeout);
-      settle(() => {
-        worker?.terminate();
-        reject(err);
-      });
-    });
-
-    worker.on("exit", (code) => {
-      clearTimeout(timeout);
-      settle(() => {
-        if (code !== 0) {
-          reject(new Error(`Agent worker exited with code ${code}`));
-        } else {
-          reject(new Error("Agent worker exited before completing"));
-        }
-      });
-    });
-
-    // Send the start command
-    worker.postMessage({
-      type: "start",
-      config: {
-        providerType: config.provider.providerType,
-        apiKey: config.provider.apiKey,
-        model: config.provider.model,
-        endpoint: config.provider.endpoint,
-        deployment: config.provider.deployment,
-        apiVersion: config.provider.apiVersion,
-        baseURL: config.provider.baseURL,
-        disableThinking: config.provider.disableThinking,
-        systemPrompt: config.systemPrompt,
-        messages: config.messages,
-        tools: config.tools,
-        maxIterations: config.maxIterations || 25,
-      },
-    });
   });
 
   const abort = () => {
-    if (worker && !settled) {
-      worker.postMessage({ type: "abort" });
-      // Give the worker 1s to clean up, then force terminate
+    if (handle.state === "settled") return;
+
+    if (handle.state === "queued" && queuedEntry) {
+      const idx = taskQueue.indexOf(queuedEntry);
+      if (idx !== -1) taskQueue.splice(idx, 1);
+      clearTimeout(queuedEntry.queueTimer);
+      handle.state = "settled";
+      queuedEntry.reject(new Error("Aborted while queued"));
+    } else if (handle.state === "dispatched" && handle.pw) {
+      const pw = handle.pw;
+      pw.worker.postMessage({ type: "abort" });
       setTimeout(() => {
-        if (!settled) {
-          worker?.terminate();
+        if (pw.task && !pw.task.settled) {
+          settleTask(pw, () => pw.task!.reject(new Error("Aborted")), true);
+          replaceWorker(pw);
         }
       }, 1000);
     }
   };
 
   return { promise, abort };
+}
+
+/* ── Pool diagnostics ──────────────────────────────────────────────── */
+
+export function getWorkerPoolStats() {
+  return {
+    poolSize: POOL_SIZE,
+    initialized: poolInitialized,
+    busyCount: pool.filter((w) => w.busy).length,
+    idleCount: pool.filter((w) => !w.busy).length,
+    queueLength: taskQueue.length,
+  };
+}
+
+/** @internal — reset pool state for testing */
+export function _resetPool() {
+  for (const pw of pool) {
+    if (pw.task) {
+      clearTimeout(pw.task.timeout);
+      pw.task = null;
+    }
+    try { pw.worker.terminate(); } catch { /* ignore */ }
+  }
+  for (const qt of taskQueue) {
+    clearTimeout(qt.queueTimer);
+  }
+  pool.length = 0;
+  taskQueue.length = 0;
+  poolInitialized = false;
 }

--- a/tests/unit/agent/worker-thread.test.ts
+++ b/tests/unit/agent/worker-thread.test.ts
@@ -11,49 +11,46 @@
 
 /* ── Mock dependencies ─────────────────────────────────────────────── */
 
-// Mock worker_threads
-const mockPostMessage = jest.fn();
-const mockTerminate = jest.fn();
-const mockOn = jest.fn();
-
+// Mock worker_threads — per-instance mocks for pool support
 class MockWorker {
-  postMessage = mockPostMessage;
-  terminate = mockTerminate;
-  on = mockOn;
+  static instances: MockWorker[] = [];
+
+  postMessage = jest.fn();
+  terminate = jest.fn();
+  private handlers: Record<string, Function> = {};
 
   constructor(_scriptPath: string) {
-    // Store for test access
-    MockWorker.lastInstance = this;
+    MockWorker.instances.push(this);
   }
 
-  static lastInstance: MockWorker | null = null;
-
-  // Helper to simulate messages from the worker
-  simulateMessage(msg: unknown) {
-    const messageHandler = mockOn.mock.calls.find(
-      ([event]: [string]) => event === "message"
-    );
-    if (messageHandler) {
-      messageHandler[1](msg);
-    }
+  on(event: string, handler: Function) {
+    this.handlers[event] = handler;
   }
 
-  simulateError(err: Error) {
-    const errorHandler = mockOn.mock.calls.find(
-      ([event]: [string]) => event === "error"
-    );
-    if (errorHandler) {
-      errorHandler[1](err);
-    }
+  async triggerMessage(msg: unknown) {
+    const handler = this.handlers["message"];
+    if (handler) await handler(msg);
   }
 
-  simulateExit(code: number) {
-    const exitHandler = mockOn.mock.calls.find(
-      ([event]: [string]) => event === "exit"
+  triggerError(err: Error) {
+    const handler = this.handlers["error"];
+    if (handler) handler(err);
+  }
+
+  triggerExit(code: number) {
+    const handler = this.handlers["exit"];
+    if (handler) handler(code);
+  }
+
+  static reset() {
+    MockWorker.instances = [];
+  }
+
+  /** Find the pool worker that received the given task (by checking postMessage calls for "start") */
+  static findTaskWorker(): MockWorker | undefined {
+    return MockWorker.instances.find((w) =>
+      w.postMessage.mock.calls.some((c: unknown[]) => (c[0] as { type: string })?.type === "start")
     );
-    if (exitHandler) {
-      exitHandler[1](code);
-    }
   }
 }
 
@@ -240,10 +237,12 @@ describe("Worker Manager — isWorkerAvailable", () => {
 describe("Worker Manager — runLlmInWorker", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    MockWorker.lastInstance = null;
+    MockWorker.reset();
+    const wm = require("@/lib/agent/worker-manager");
+    wm._resetPool();
   });
 
-  test("spawns a worker and resolves on 'done' message", async () => {
+  test("dispatches task to a pool worker and resolves on 'done'", async () => {
     const { runLlmInWorker } = require("@/lib/agent/worker-manager");
 
     const onToken = jest.fn();
@@ -260,23 +259,20 @@ describe("Worker Manager — runLlmInWorker", () => {
       onStatus
     );
 
-    // Worker was created
-    expect(MockWorker.lastInstance).not.toBeNull();
-
-    // Simulate worker sending tokens
-    const messageHandler = mockOn.mock.calls.find(([e]: [string]) => e === "message")?.[1];
-    expect(messageHandler).toBeDefined();
+    // Pool creates workers, find the one with the task
+    const taskWorker = MockWorker.findTaskWorker();
+    expect(taskWorker).toBeDefined();
 
     // Send a token
-    await messageHandler({ type: "token", data: "Hello" });
+    await taskWorker!.triggerMessage({ type: "token", data: "Hello" });
     expect(onToken).toHaveBeenCalledWith("Hello");
 
     // Send status
-    await messageHandler({ type: "status", data: { step: "Generating", detail: "Iteration 1" } });
+    await taskWorker!.triggerMessage({ type: "status", data: { step: "Generating", detail: "Iteration 1" } });
     expect(onStatus).toHaveBeenCalledWith({ step: "Generating", detail: "Iteration 1" });
 
     // Send done
-    await messageHandler({
+    await taskWorker!.triggerMessage({
       type: "done",
       data: { content: "Test response", toolsUsed: [], iterations: 1 },
     });
@@ -306,10 +302,10 @@ describe("Worker Manager — runLlmInWorker", () => {
       onToolRequest
     );
 
-    const messageHandler = mockOn.mock.calls.find(([e]: [string]) => e === "message")?.[1];
+    const taskWorker = MockWorker.findTaskWorker()!;
 
     // Worker requests tool execution
-    await messageHandler({
+    await taskWorker.triggerMessage({
       type: "tool_request",
       requestId: "tr_1",
       calls: [{ id: "tc-1", name: "web_search", arguments: { query: "test" } }],
@@ -322,14 +318,14 @@ describe("Worker Manager — runLlmInWorker", () => {
     );
 
     // Verify tool results were posted back to worker
-    expect(mockPostMessage).toHaveBeenCalledWith({
+    expect(taskWorker.postMessage).toHaveBeenCalledWith({
       type: "tool_result",
       requestId: "tr_1",
       results: toolResults,
     });
 
     // Complete the worker
-    await messageHandler({
+    await taskWorker.triggerMessage({
       type: "done",
       data: { content: "Search complete", toolsUsed: ["web_search"], iterations: 2 },
     });
@@ -351,13 +347,13 @@ describe("Worker Manager — runLlmInWorker", () => {
       }
     );
 
-    const messageHandler = mockOn.mock.calls.find(([e]: [string]) => e === "message")?.[1];
-    await messageHandler({ type: "error", data: "API key invalid" });
+    const taskWorker = MockWorker.findTaskWorker()!;
+    await taskWorker.triggerMessage({ type: "error", data: "API key invalid" });
 
     await expect(promise).rejects.toThrow("API key invalid");
   });
 
-  test("rejects on worker process error", async () => {
+  test("rejects on worker process error and replaces worker", async () => {
     const { runLlmInWorker } = require("@/lib/agent/worker-manager");
 
     const { promise } = runLlmInWorker(
@@ -369,16 +365,19 @@ describe("Worker Manager — runLlmInWorker", () => {
       }
     );
 
-    const errorHandler = mockOn.mock.calls.find(([e]: [string]) => e === "error")?.[1];
-    errorHandler(new Error("Worker crashed"));
+    const taskWorker = MockWorker.findTaskWorker()!;
+    const instanceCountBefore = MockWorker.instances.length;
+    taskWorker.triggerError(new Error("Worker crashed"));
 
     await expect(promise).rejects.toThrow("Worker crashed");
+    // A replacement worker was spawned
+    expect(MockWorker.instances.length).toBe(instanceCountBefore + 1);
   });
 
-  test("abort sends abort message and terminates", async () => {
+  test("abort sends abort message to the dispatched worker", async () => {
     const { runLlmInWorker } = require("@/lib/agent/worker-manager");
 
-    const { abort } = runLlmInWorker(
+    const { promise, abort } = runLlmInWorker(
       {
         provider: { providerType: "openai", apiKey: "sk-test" },
         systemPrompt: "Test",
@@ -386,15 +385,17 @@ describe("Worker Manager — runLlmInWorker", () => {
         tools: [],
       }
     );
+    promise.catch(() => {}); // suppress expected rejection
 
+    const taskWorker = MockWorker.findTaskWorker()!;
     abort();
-    expect(mockPostMessage).toHaveBeenCalledWith({ type: "abort" });
+    expect(taskWorker.postMessage).toHaveBeenCalledWith({ type: "abort" });
   });
 
-  test("sends start config to worker on spawn", () => {
+  test("sends start config to the pool worker", () => {
     const { runLlmInWorker } = require("@/lib/agent/worker-manager");
 
-    runLlmInWorker({
+    const { promise } = runLlmInWorker({
       provider: {
         providerType: "anthropic",
         apiKey: "sk-ant-test",
@@ -405,9 +406,10 @@ describe("Worker Manager — runLlmInWorker", () => {
       tools: [{ name: "web_search", description: "Search", inputSchema: {} }],
       maxIterations: 10,
     });
+    promise.catch(() => {}); // suppress timeout rejection
 
-    // First postMessage should be the start config
-    expect(mockPostMessage).toHaveBeenCalledWith({
+    const taskWorker = MockWorker.findTaskWorker()!;
+    expect(taskWorker.postMessage).toHaveBeenCalledWith({
       type: "start",
       config: expect.objectContaining({
         providerType: "anthropic",
@@ -456,7 +458,9 @@ describe("Loop Worker — runAgentLoopWithWorker fallback", () => {
 describe("Worker Manager — timeout", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    MockWorker.lastInstance = null;
+    MockWorker.reset();
+    const wm = require("@/lib/agent/worker-manager");
+    wm._resetPool();
     jest.useFakeTimers();
   });
 
@@ -487,7 +491,8 @@ describe("Worker Manager — timeout", () => {
     jest.advanceTimersByTime(1_000);
 
     await expect(promise).rejects.toThrow("Agent worker timed out after 30s");
-    expect(mockTerminate).toHaveBeenCalled();
+    const taskWorker = MockWorker.findTaskWorker()!;
+    expect(taskWorker.terminate).toHaveBeenCalled();
   });
 });
 
@@ -529,5 +534,173 @@ describe("Worker Script — agent-worker.js", () => {
     expect(code).toContain("providerType === 'litellm'");
     expect(code).toContain("'/v1'");
     expect(code).toMatch(/effectiveBaseURL.*\/v1/);
+  });
+
+  test("worker script resets state between tasks for pool reuse", () => {
+    const path = require("path");
+    const realFs = jest.requireActual("fs");
+    const workerPath = path.join(process.cwd(), "scripts", "agent-worker.js");
+    const code = realFs.readFileSync(workerPath, "utf-8");
+    // Must reset aborted flag and clear pending resolvers
+    expect(code).toContain("aborted = false");
+    expect(code).toContain("toolResultResolvers.clear()");
+  });
+});
+
+/* ── Worker Pool ───────────────────────────────────────────────────── */
+
+describe("Worker Pool — pool behavior", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    MockWorker.reset();
+    const wm = require("@/lib/agent/worker-manager");
+    wm._resetPool();
+  });
+
+  test("pool creates default number of workers on first runLlmInWorker call", () => {
+    const { runLlmInWorker } = require("@/lib/agent/worker-manager");
+
+    runLlmInWorker({
+      provider: { providerType: "openai", apiKey: "sk-test" },
+      systemPrompt: "Test",
+      messages: [{ role: "user", content: "Hi" }],
+      tools: [],
+    });
+
+    // Default pool size is 2
+    expect(MockWorker.instances.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("reuses workers for sequential tasks (no new workers spawned)", async () => {
+    const { runLlmInWorker } = require("@/lib/agent/worker-manager");
+
+    // Task 1
+    const { promise: p1 } = runLlmInWorker({
+      provider: { providerType: "openai", apiKey: "sk-test" },
+      systemPrompt: "Test",
+      messages: [{ role: "user", content: "Task 1" }],
+      tools: [],
+    });
+
+    const countAfterFirst = MockWorker.instances.length;
+    const taskWorker1 = MockWorker.findTaskWorker()!;
+
+    // Complete task 1
+    await taskWorker1.triggerMessage({
+      type: "done",
+      data: { content: "Done 1", toolsUsed: [], iterations: 1 },
+    });
+    await p1;
+
+    // Task 2 — should reuse existing pool worker, no new spawn
+    const { promise: p2 } = runLlmInWorker({
+      provider: { providerType: "openai", apiKey: "sk-test" },
+      systemPrompt: "Test",
+      messages: [{ role: "user", content: "Task 2" }],
+      tools: [],
+    });
+
+    expect(MockWorker.instances.length).toBe(countAfterFirst);
+
+    // Complete task 2
+    const taskWorker2 = MockWorker.instances.find(
+      (w) => w.postMessage.mock.calls.filter(
+        (c: unknown[]) => (c[0] as { type: string })?.type === "start"
+      ).length > 0 && !w.terminate.mock.calls.length
+    )!;
+    await taskWorker2.triggerMessage({
+      type: "done",
+      data: { content: "Done 2", toolsUsed: [], iterations: 1 },
+    });
+    await p2;
+  });
+
+  test("replaces crashed workers with new ones", async () => {
+    const { runLlmInWorker } = require("@/lib/agent/worker-manager");
+
+    const { promise } = runLlmInWorker({
+      provider: { providerType: "openai", apiKey: "sk-test" },
+      systemPrompt: "Test",
+      messages: [{ role: "user", content: "Hello" }],
+      tools: [],
+    });
+
+    const countBeforeCrash = MockWorker.instances.length;
+    const taskWorker = MockWorker.findTaskWorker()!;
+
+    // Simulate crash
+    taskWorker.triggerError(new Error("Segfault"));
+
+    await expect(promise).rejects.toThrow("Segfault");
+    // A replacement was spawned
+    expect(MockWorker.instances.length).toBe(countBeforeCrash + 1);
+    // Original was terminated
+    expect(taskWorker.terminate).toHaveBeenCalled();
+  });
+
+  test("getWorkerPoolStats returns correct info", async () => {
+    const { runLlmInWorker, getWorkerPoolStats } = require("@/lib/agent/worker-manager");
+
+    // Before any call — pool not initialized
+    const statsBefore = getWorkerPoolStats();
+    expect(statsBefore.initialized).toBe(false);
+
+    // Start a task to trigger pool init
+    const { promise } = runLlmInWorker({
+      provider: { providerType: "openai", apiKey: "sk-test" },
+      systemPrompt: "Test",
+      messages: [{ role: "user", content: "Hi" }],
+      tools: [],
+    });
+
+    const statsActive = getWorkerPoolStats();
+    expect(statsActive.initialized).toBe(true);
+    expect(statsActive.busyCount).toBe(1);
+    expect(statsActive.idleCount).toBeGreaterThanOrEqual(1);
+
+    // Complete the task
+    const taskWorker = MockWorker.findTaskWorker()!;
+    await taskWorker.triggerMessage({
+      type: "done",
+      data: { content: "Done", toolsUsed: [], iterations: 1 },
+    });
+    await promise;
+
+    const statsAfter = getWorkerPoolStats();
+    expect(statsAfter.busyCount).toBe(0);
+  });
+});
+
+describe("Worker Pool — source verification", () => {
+  const readSource = () => {
+    const realFs = jest.requireActual("fs");
+    const path = require("path");
+    return realFs.readFileSync(
+      path.join(process.cwd(), "src", "lib", "agent", "worker-manager.ts"),
+      "utf-8"
+    ) as string;
+  };
+
+  test("uses WORKER_POOL_SIZE env var for configuration", () => {
+    const code = readSource();
+    expect(code).toContain("WORKER_POOL_SIZE");
+    expect(code).toContain("process.env.WORKER_POOL_SIZE");
+  });
+
+  test("has drainQueue for task queuing when all workers busy", () => {
+    const code = readSource();
+    expect(code).toContain("drainQueue");
+    expect(code).toContain("taskQueue");
+  });
+
+  test("has replaceWorker for crash recovery", () => {
+    const code = readSource();
+    expect(code).toContain("replaceWorker");
+    expect(code).toContain("Worker crashed and was replaced");
+  });
+
+  test("exports getWorkerPoolStats for monitoring", () => {
+    const code = readSource();
+    expect(code).toContain("export function getWorkerPoolStats");
   });
 });


### PR DESCRIPTION
Closes #10

## Changes
- **Worker pool**: Replace per-request worker thread spawn with a reusable pool (default 2 threads, configurable 1-8 via \WORKER_POOL_SIZE\ env var)
- **Worker recycling**: Workers stay alive between tasks; \gent-worker.js\ resets \borted\ flag and \	oolResultResolvers\ between tasks
- **Queue**: When all workers are busy, tasks are queued with 30s timeout and dispatched as workers become idle
- **Crash recovery**: Crashed workers are automatically terminated, replaced, and logged (\eplaceWorker\)
- **Diagnostics**: \getWorkerPoolStats()\ exposes pool size, busy/idle counts, and queue length
- **Tests**: 9 new tests (pool behavior + source verification), 1242 total passing
- **Docs**: Updated ARCHITECTURE.md and TECH_SPECS.md

## Verification
- 1242 tests across 96 suites  all passing
- 0 vulnerabilities (npm audit)